### PR TITLE
display: guard use of kernel headers

### DIFF
--- a/gpu_tonemapper/Android.mk
+++ b/gpu_tonemapper/Android.mk
@@ -12,7 +12,9 @@ LOCAL_MODULE              := libgpu_tonemapper
 LOCAL_VENDOR_MODULE       := true
 LOCAL_MODULE_TAGS         := optional
 LOCAL_C_INCLUDES          := $(TARGET_OUT_HEADERS)/qcom/display/
+ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
 LOCAL_C_INCLUDES          += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
+endif
 LOCAL_SHARED_LIBRARIES    := libEGL libGLESv2 libui libutils liblog
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps) $(kernel_deps)
 

--- a/libdrmutils/Android.mk
+++ b/libdrmutils/Android.mk
@@ -5,7 +5,9 @@ LOCAL_MODULE                  := libdrmutils
 LOCAL_VENDOR_MODULE           := true
 LOCAL_MODULE_TAGS             := optional
 LOCAL_C_INCLUDES              := external/libdrm \
-                                 $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
+ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
+LOCAL_C_INCLUDES          += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
+endif
 LOCAL_SHARED_LIBRARIES        := libdrm libdl
 LOCAL_CFLAGS                  := -DLOG_TAG=\"DRMUTILS\" -Wall -std=c++11 -Werror -fno-operator-names
 LOCAL_CLANG                   := true


### PR DESCRIPTION
kernel headers are not always available whilst building so do not depend on them