### PR TITLE
[DISPLAY] Fixes for legacy devices

### DIFF
--- a/libqdutils/qdMetaData.cpp
+++ b/libqdutils/qdMetaData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2018, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -119,11 +119,29 @@ int setMetaDataVa(MetaData_t *data, DispParamType paramType,
         case SET_VT_TIMESTAMP:
             data->vtTimeStamp = *((uint64_t *)param);
             break;
-        case COLOR_METADATA:
+        case COLOR_METADATA: {
 #ifdef USE_COLOR_METADATA
             data->color = *((ColorMetaData *)param);
+#else
+            ColorMetaData *color = (ColorMetaData *)param;
+            switch (color->colorPrimaries) {
+                case ColorPrimaries_BT709_5:
+                    data->colorSpace = ITU_R_709;
+                    break;
+                case ColorPrimaries_BT601_6_525:
+                case ColorPrimaries_BT601_6_625:
+                    data->colorSpace = ((color->range) ? ITU_R_601_FR : ITU_R_601);
+                    break;
+                case ColorPrimaries_BT2020:
+                    data->colorSpace = ((color->range) ? ITU_R_2020_FR : ITU_R_2020);
+                    break;
+                default:
+                    data->colorSpace = ITU_R_601;
+                    break;
+            }
 #endif
             break;
+	}
         case SET_UBWC_CR_STATS_INFO: {
              struct UBWCStats* stats = (struct UBWCStats*)param;
              int numelems = sizeof(data->ubwcCRStats) / sizeof(struct UBWCStats);

--- a/libqdutils/qdMetaData.h
+++ b/libqdutils/qdMetaData.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2017, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2012-2018, The Linux Foundation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -30,9 +30,7 @@
 #ifndef _QDMETADATA_H
 #define _QDMETADATA_H
 
-#ifdef USE_COLOR_METADATA
 #include <color_metadata.h>
-#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/sdm/libs/hwc2/hwc_session.cpp
+++ b/sdm/libs/hwc2/hwc_session.cpp
@@ -584,6 +584,7 @@ int32_t HWCSession::RegisterCallback(hwc2_device_t *device, int32_t descriptor,
   SCOPE_LOCK(hwc_session->callbacks_lock_);
   auto desc = static_cast<HWC2::Callback>(descriptor);
   auto error = hwc_session->callbacks_.Register(desc, callback_data, pointer);
+  hwc_session->callbacks_lock_.Broadcast();
   DLOGD("Registering callback: %s", to_string(desc).c_str());
   if (descriptor == HWC2_CALLBACK_HOTPLUG) {
     if (hwc_session->hwc_display_[HWC_DISPLAY_PRIMARY]) {
@@ -591,7 +592,6 @@ int32_t HWCSession::RegisterCallback(hwc2_device_t *device, int32_t descriptor,
     }
   }
   hwc_session->need_invalidate_ = false;
-  hwc_session->callbacks_lock_.Broadcast();
   return INT32(error);
 }
 


### PR DESCRIPTION
This is intended to fix the boot delays due to surfaceflinger deadlocking and some vidc issues due to bad color metadata got from the display qdutils.

