### PR TITLE
display: backport oreo changes

### DIFF
--- a/libgralloc1/gr_adreno_info.cpp
+++ b/libgralloc1/gr_adreno_info.cpp
@@ -60,8 +60,6 @@ AdrenoMemInfo::AdrenoMemInfo() {
   if (libadreno_utils_) {
     *reinterpret_cast<void **>(&LINK_adreno_compute_aligned_width_and_height) =
         ::dlsym(libadreno_utils_, "compute_aligned_width_and_height");
-    *reinterpret_cast<void **>(&LINK_adreno_compute_fmt_aligned_width_and_height) =
-        ::dlsym(libadreno_utils_, "compute_fmt_aligned_width_and_height");
     *reinterpret_cast<void **>(&LINK_adreno_compute_padding) =
         ::dlsym(libadreno_utils_, "compute_surface_padding");
     *reinterpret_cast<void **>(&LINK_adreno_compute_compressedfmt_aligned_width_and_height) =
@@ -127,15 +125,7 @@ void AdrenoMemInfo::AlignUnCompressedRGB(int width, int height, int format, int 
   int padding_threshold = 512;  // Threshold for padding surfaces.
   // the function below computes aligned width and aligned height
   // based on linear or macro tile mode selected.
-  if (LINK_adreno_compute_fmt_aligned_width_and_height) {
-    // We call into adreno_utils only for RGB formats. So plane_id is 0 and
-    // num_samples is 1 always. We may  have to add uitility function to
-    // find out these if there is a need to call this API for YUV formats.
-    LINK_adreno_compute_fmt_aligned_width_and_height(
-        width, height, 0/*plane_id*/, GetGpuPixelFormat(format), 1/*num_samples*/,
-        tile_enabled, raster_mode, padding_threshold,
-        reinterpret_cast<int *>(aligned_w), reinterpret_cast<int *>(aligned_h));
-  } else if (LINK_adreno_compute_aligned_width_and_height) {
+  if (LINK_adreno_compute_aligned_width_and_height) {
     LINK_adreno_compute_aligned_width_and_height(
         width, height, bpp, tile_enabled, raster_mode, padding_threshold,
         reinterpret_cast<int *>(aligned_w), reinterpret_cast<int *>(aligned_h));
@@ -147,7 +137,6 @@ void AdrenoMemInfo::AlignUnCompressedRGB(int width, int height, int format, int 
   } else {
     ALOGW(
         "%s: Warning!! Symbols compute_surface_padding and "
-        "compute_fmt_aligned_width_and_height and "
         "compute_aligned_width_and_height not found",
         __FUNCTION__);
   }

--- a/libgralloc1/gr_adreno_info.h
+++ b/libgralloc1/gr_adreno_info.h
@@ -131,11 +131,6 @@ class AdrenoMemInfo {
                                                        int tile_mode, int raster_mode,
                                                        int padding_threshold, int *aligned_w,
                                                        int *aligned_h) = NULL;
-  void (*LINK_adreno_compute_fmt_aligned_width_and_height)(int width, int height, int plane_id,
-                                                           int format, int num_samples,
-                                                           int tile_mode, int raster_mode,
-                                                           int padding_threshold, int *aligned_w,
-                                                           int *aligned_h) = NULL;
   void (*LINK_adreno_compute_compressedfmt_aligned_width_and_height)(
       int width, int height, int format, int tile_mode, int raster_mode, int padding_threshold,
       int *aligned_w, int *aligned_h, int *bpp) = NULL;

--- a/libgralloc1/gr_utils.cpp
+++ b/libgralloc1/gr_utils.cpp
@@ -28,6 +28,7 @@
  */
 
 #include <media/msm_media_info.h>
+#include <cutils/properties.h>
 #include <algorithm>
 
 #include "gr_utils.h"
@@ -517,6 +518,9 @@ bool IsUBwcSupported(int format) {
 
 bool IsUBwcEnabled(int format, gralloc1_producer_usage_t prod_usage,
                    gralloc1_consumer_usage_t cons_usage) {
+  // Property is used to check whether the video encoder supports UBWC
+  char property[PROPERTY_VALUE_MAX];
+
   // Allow UBWC, if client is using an explicitly defined UBWC pixel format.
   if (IsUBwcFormat(format)) {
     return true;
@@ -533,6 +537,12 @@ bool IsUBwcEnabled(int format, gralloc1_producer_usage_t prod_usage,
       if (AdrenoMemInfo::GetInstance()) {
         enable = AdrenoMemInfo::GetInstance()->IsUBWCSupportedByGPU(format);
       }
+    }
+
+    // Check if client is video encoder, and UBWC is disabled by a prop
+    if ((cons_usage & GRALLOC1_CONSUMER_USAGE_VIDEO_ENCODER) &&
+        (property_get("video.disable.ubwc", property, "0") > 0)) {
+      enable = atoi(property) == 0;
     }
 
     // Allow UBWC, only if CPU usage flags are not set

--- a/sdm/libs/core/display_base.cpp
+++ b/sdm/libs/core/display_base.cpp
@@ -504,17 +504,58 @@ DisplayError DisplayBase::SetActiveConfig(uint32_t index) {
   lock_guard<recursive_mutex> obj(recursive_mutex_);
   DisplayError error = kErrorNone;
   uint32_t active_index = 0;
+  HWDisplayAttributes display_attrs;
+  HWMixerAttributes   mixer_attrs;
+  HWPanelInfo         hw_panel_info;
+  DisplayConfigVariableInfo fb_config = fb_config_;
 
   hw_intf_->GetActiveConfig(&active_index);
-
   if (active_index == index) {
     return kErrorNone;
   }
 
+  error = hw_intf_->GetDisplayAttributes(index, &display_attrs);
+  if (error != kErrorNone)
+    return error;
+
+  error = hw_intf_->GetHWPanelInfo(&hw_panel_info);
+  if (error != kErrorNone) {
+    DLOGE("Cannot get panel info.");
+    return error;
+  }
+
+  /* Now we can start doing the real magic */
   error = hw_intf_->SetDisplayAttributes(index);
   if (error != kErrorNone) {
     return error;
   }
+
+  error = hw_intf_->GetMixerAttributes(&mixer_attrs);
+  if (error != kErrorNone) {
+    return error;
+  }
+  DLOGI("Current mixer attributes: w%d h%d s%d",
+        mixer_attrs.width, mixer_attrs.height,
+        mixer_attrs.split_left);
+
+  mixer_attrs.split_left = display_attrs.is_device_split ?
+    hw_panel_info.split_info.left_split : mixer_attributes_.width;
+
+  if (mixer_attrs.split_left != mixer_attributes_.split_left) {
+    DLOGI("Setting mixer left split to %d", mixer_attrs.split_left);
+
+    error = hw_intf_->SetMixerAttributes(mixer_attrs);
+    if (error != kErrorNone)
+      DLOGW("Cannot set new mixer attributes.");
+  }
+
+  fb_config.x_pixels = display_attrs.x_pixels;
+  fb_config.y_pixels = display_attrs.y_pixels;
+  SetMixerResolution(fb_config.x_pixels, fb_config.y_pixels);
+
+  display_attributes_ = display_attrs;
+  mixer_attributes_ = mixer_attrs;
+  fb_config_ = fb_config;
 
   return ReconfigureDisplay();
 }


### PR DESCRIPTION
2d17f22caea0459d96845e17f2dcd5aa653d2238 is not compat with loire's adreno API.
This revert will fix loire's pixel format.
Not sure if it will affect other platform so:

ping @alviteri
ping @oshmoun
ping @tomgus1 