### PR TITLE
sdm: hwc2: Added property to disable skipping client

### DIFF
--- a/sdm/libs/hwc2/hwc_session.cpp
+++ b/sdm/libs/hwc2/hwc_session.cpp
@@ -303,16 +303,23 @@ void HWCSession::GetCapabilities(struct hwc2_device *device, uint32_t *outCount,
   }
 
   int value = 0;
+  bool skip_client_color_transform = true;
   bool disable_skip_validate = false;
   if (Debug::Get()->GetProperty("sdm.debug.disable_skip_validate", &value) == kErrorNone) {
     disable_skip_validate = (value == 1);
   }
-  uint32_t count = 1 + (disable_skip_validate ? 0 : 1);
+  if (Debug::Get()->GetProperty("persist.hwc2.skip_client_color_transform", &value) == kErrorNone) {
+    skip_client_color_transform = (value == 1);
+  }
+  uint32_t count = (skip_client_color_transform ? 1 : 0) + (disable_skip_validate ? 0 : 1);
 
   if (outCapabilities != nullptr && (*outCount >= count)) {
-    outCapabilities[0] = HWC2_CAPABILITY_SKIP_CLIENT_COLOR_TRANSFORM;
+    DLOGI("skip_client_color_transform %d", skip_client_color_transform);
+    if (skip_client_color_transform) {
+	    outCapabilities[0] = HWC2_CAPABILITY_SKIP_CLIENT_COLOR_TRANSFORM;
+    }
     if (!disable_skip_validate) {
-      outCapabilities[1] = HWC2_CAPABILITY_SKIP_VALIDATE;
+      outCapabilities[count - 1] = HWC2_CAPABILITY_SKIP_VALIDATE;
     }
   }
   *outCount = count;


### PR DESCRIPTION
Selectively allow Client Compositor to apply color transforms. Useful on
platforms that do not support these transforms in the Device Compositor.

Ported from msm8998@aosp: 8e74401d92723d564d299ff695a05a6f1b050eb4
Signed-off-by: Humberto Borba <humberos@omnirom.org>