### PR TITLE
[6.3.r1] Revert "add the missing header"

### DIFF
--- a/libgralloc1/gr_priv_handle.h
+++ b/libgralloc1/gr_priv_handle.h
@@ -26,7 +26,6 @@
 #include <hardware/gralloc1.h>
 #include <hardware/gralloc.h>
 #include <cinttypes>
-#include <errno.h>
 
 #define GRALLOC1_FUNCTION_PERFORM 0x00001000
 


### PR DESCRIPTION
This reverts commit bb29c2ae51963b5d9c9a9e630f0ea40ba045a152.

Already included in this commit: 50002d6735a1f6dacb42d53afb1d442192c1ea68