### PR TITLE
deprecate cutils/log.h

### DIFF
--- a/hdmi_cec/qhdmi_cec.cpp
+++ b/hdmi_cec/qhdmi_cec.cpp
@@ -30,7 +30,7 @@
 #define DEBUG 0
 #define ATRACE_TAG (ATRACE_TAG_GRAPHICS | ATRACE_TAG_HAL)
 #include <cstdlib>
-#include <cutils/log.h>
+#include <log/log.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <hardware/hdmi_cec.h>

--- a/libcopybit/copybit.cpp
+++ b/libcopybit/copybit.cpp
@@ -18,7 +18,7 @@
  * limitations under the License.
  */
 
-#include <cutils/log.h>
+#include <log/log.h>
 
 #include <linux/msm_mdp.h>
 #include <linux/fb.h>

--- a/libcopybit/copybit_c2d.cpp
+++ b/libcopybit/copybit_c2d.cpp
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cutils/log.h>
+#include <log/log.h>
 #include <sys/resource.h>
 #include <sys/prctl.h>
 

--- a/libcopybit/software_converter.cpp
+++ b/libcopybit/software_converter.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <cutils/log.h>
+#include <log/log.h>
 #include <stdlib.h>
 #include <errno.h>
 #include "software_converter.h"

--- a/libgralloc/gralloc_priv.h
+++ b/libgralloc/gralloc_priv.h
@@ -36,7 +36,7 @@
 
 #include <cutils/native_handle.h>
 
-#include <cutils/log.h>
+#include <log/log.h>
 
 #define ROUND_UP_PAGESIZE(x) (unsigned int)( ((x) + getpagesize()-1)  & \
                                              (~(getpagesize()-1)) )

--- a/libgralloc1/gr_adreno_info.cpp
+++ b/libgralloc1/gr_adreno_info.cpp
@@ -29,7 +29,7 @@
 
 #include <string.h>
 
-#include <cutils/log.h>
+#include <log/log.h>
 #include <cutils/properties.h>
 #include <dlfcn.h>
 #include <mutex>

--- a/libgralloc1/gr_allocator.cpp
+++ b/libgralloc1/gr_allocator.cpp
@@ -27,7 +27,7 @@
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <cutils/log.h>
+#include <log/log.h>
 #include <algorithm>
 #include <vector>
 

--- a/libgralloc1/gr_device_impl.cpp
+++ b/libgralloc1/gr_device_impl.cpp
@@ -28,7 +28,7 @@
  */
 
 #define ATRACE_TAG (ATRACE_TAG_GRAPHICS | ATRACE_TAG_HAL)
-#include <cutils/log.h>
+#include <log/log.h>
 #include <utils/Trace.h>
 #include <cutils/trace.h>
 #include <sync/sync.h>

--- a/libgralloc1/gr_ion_alloc.cpp
+++ b/libgralloc1/gr_ion_alloc.cpp
@@ -33,7 +33,7 @@
 #include <sys/mman.h>
 #include <stdlib.h>
 #include <fcntl.h>
-#include <cutils/log.h>
+#include <log/log.h>
 #include <errno.h>
 #include <utils/Trace.h>
 #include <cutils/trace.h>

--- a/libgralloc1/gr_priv_handle.h
+++ b/libgralloc1/gr_priv_handle.h
@@ -22,7 +22,7 @@
 
 #include <errno.h>
 
-#include <cutils/log.h>
+#include <log/log.h>
 #include <hardware/gralloc1.h>
 #include <hardware/gralloc.h>
 #include <cinttypes>

--- a/liblight/lights.c
+++ b/liblight/lights.c
@@ -19,7 +19,7 @@
 
 // #define LOG_NDEBUG 0
 
-#include <cutils/log.h>
+#include <log/log.h>
 #include <cutils/properties.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/libqdutils/profiler.h
+++ b/libqdutils/profiler.h
@@ -33,7 +33,7 @@
 #include <stdio.h>
 #include <utils/Singleton.h>
 #include <cutils/properties.h>
-#include <cutils/log.h>
+#include <log/log.h>
 
 #ifndef DEBUG_CALC_FPS
 #define CALC_FPS() ((void)0)

--- a/libqdutils/qdMetaData.cpp
+++ b/libqdutils/qdMetaData.cpp
@@ -30,7 +30,7 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/mman.h>
-#include <cutils/log.h>
+#include <log/log.h>
 #include <cinttypes>
 #include <gralloc_priv.h>
 #include "qdMetaData.h"

--- a/libqservice/QService.h
+++ b/libqservice/QService.h
@@ -32,7 +32,7 @@
 
 #include <utils/Errors.h>
 #include <sys/types.h>
-#include <cutils/log.h>
+#include <log/log.h>
 #include <binder/IServiceManager.h>
 #include <IQService.h>
 #include <IQClient.h>

--- a/sdm/libs/hwc2/hwc_debugger.h
+++ b/sdm/libs/hwc2/hwc_debugger.h
@@ -34,7 +34,7 @@
 
 #include <core/sdm_types.h>
 #include <core/debug_interface.h>
-#include <cutils/log.h>
+#include <log/log.h>
 #include <utils/Trace.h>
 #include <bitset>
 


### PR DESCRIPTION
to supress warnings in build

Signed-off-by: David Viteri <davidteri91@gmail.com>