### PR TITLE
make hal compatible with sdm845 media hal from aosp

### DIFF
--- a/libcopybit/c2d2.h
+++ b/libcopybit/c2d2.h
@@ -207,6 +207,7 @@ typedef enum {
     C2D_COLOR_FORMAT_422_Y42B     = 174,
 
     C2D_COLOR_FORMAT_800_Y800     = 190,
+    C2D_COLOR_FORMAT_420_TP10     = 191,
 
 } C2D_YUV_FORMAT;
 

--- a/sdm/libs/core/display_base.cpp
+++ b/sdm/libs/core/display_base.cpp
@@ -173,7 +173,7 @@ DisplayError DisplayBase::BuildLayerStackStats(LayerStack *layer_stack) {
     }
   }
 
-  DLOGD_IF(kTagDisplay, "LayerStack layer_count: %d, app_layer_count: %d, gpu_target_index: %d, "
+  DLOGV_IF(kTagDisplay, "LayerStack layer_count: %d, app_layer_count: %d, gpu_target_index: %d, "
            "display: %d-%d", layers.size(), hw_layers_info.app_layer_count,
            hw_layers_info.gpu_target_index, display_id_, display_type_);
 


### PR DESCRIPTION
a color format was missing, so add it to avoid compilation issues when building with the sdm845 media hal from aosp.
additionally, lower log level to avoid log spam.