### PR TITLE
[DISPLAY-7.3.r1] allocators: Add gralloc1 for legacy devices

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -7,7 +7,11 @@ ifneq ($(TARGET_IS_HEADLESS), true)
                     $(sdm-libs)/hwc2 gpu_tonemapper libdrmutils libdisplayconfig
 endif
 
+ifeq ($(TARGET_USES_GRALLOC1), true)
+display-hals += gralloc1
+else
 display-hals += gralloc
+endif
 
 ifeq ($(call is-vendor-board-platform,QCOM),true)
     include $(call all-named-subdir-makefiles,$(display-hals))

--- a/common.mk
+++ b/common.mk
@@ -9,7 +9,11 @@ display_config_version := $(shell \
 #Common C flags
 common_flags := -Wno-missing-field-initializers
 common_flags += -Wconversion -Wall -Werror -std=c++14
+
+ifeq ($(TARGET_USES_GRALLOC1), true)
 common_flags += -DUSE_GRALLOC1
+endif
+
 ifeq ($(TARGET_IS_HEADLESS), true)
     common_flags += -DTARGET_HEADLESS
     LOCAL_CLANG := false

--- a/gralloc1/Android.mk
+++ b/gralloc1/Android.mk
@@ -1,0 +1,43 @@
+# Gralloc module
+LOCAL_PATH := $(call my-dir)
+include $(LOCAL_PATH)/../common.mk
+include $(CLEAR_VARS)
+
+LOCAL_MODULE                  := gralloc.$(TARGET_BOARD_PLATFORM)
+LOCAL_VENDOR_MODULE           := true
+LOCAL_MODULE_RELATIVE_PATH    := hw
+LOCAL_MODULE_TAGS             := optional
+LOCAL_C_INCLUDES              := $(common_includes) \
+                                 external/libcxx/include/
+
+LOCAL_HEADER_LIBRARIES        := display_headers
+LOCAL_SHARED_LIBRARIES        := $(common_libs) libqdMetaData libsync libgrallocutils
+LOCAL_CFLAGS                  := $(common_flags) -DLOG_TAG=\"qdgralloc\" -Wall -std=c++11 -Werror
+LOCAL_CFLAGS                  += -isystem  $(kernel_includes)
+LOCAL_CLANG                   := true
+LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps) $(kernel_deps)
+LOCAL_SRC_FILES               := gr_ion_alloc.cpp \
+                                 gr_allocator.cpp \
+                                 gr_buf_mgr.cpp \
+                                 gr_device_impl.cpp
+LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)
+LOCAL_COPY_HEADERS            := gr_device_impl.h gralloc_priv.h gr_priv_handle.h
+
+ifeq ($(call is-board-platform-in-list, msm8909), true)
+    LOCAL_CFLAGS += -DUSE_SECURE_HEAP
+endif
+
+include $(BUILD_SHARED_LIBRARY)
+
+#libgrallocutils
+include $(CLEAR_VARS)
+LOCAL_MODULE                  := libgrallocutils
+LOCAL_VENDOR_MODULE           := true
+LOCAL_MODULE_TAGS             := optional
+LOCAL_C_INCLUDES              := $(common_includes) $(kernel_includes)
+LOCAL_HEADER_LIBRARIES        := display_headers
+LOCAL_SHARED_LIBRARIES        := $(common_libs) libqdMetaData libdl
+LOCAL_CFLAGS                  := $(common_flags) -DLOG_TAG=\"grallocutils\" -Wno-sign-conversion
+LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps) $(kernel_deps)
+LOCAL_SRC_FILES               := gr_utils.cpp gr_adreno_info.cpp
+include $(BUILD_SHARED_LIBRARY)

--- a/gralloc1/gr_adreno_info.cpp
+++ b/gralloc1/gr_adreno_info.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2011-2018, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <log/log.h>
+#include <cutils/properties.h>
+#include <dlfcn.h>
+#include <mutex>
+
+#include "gralloc_priv.h"
+#include "gr_adreno_info.h"
+#include "gr_utils.h"
+
+using std::lock_guard;
+using std::mutex;
+
+namespace gralloc1 {
+
+AdrenoMemInfo *AdrenoMemInfo::s_instance = nullptr;
+
+AdrenoMemInfo *AdrenoMemInfo::GetInstance() {
+  static mutex s_lock;
+  lock_guard<mutex> obj(s_lock);
+  if (!s_instance) {
+    s_instance = new AdrenoMemInfo();
+  }
+
+  return s_instance;
+}
+
+AdrenoMemInfo::AdrenoMemInfo() {
+  libadreno_utils_ = ::dlopen("libadreno_utils.so", RTLD_NOW);
+  if (libadreno_utils_) {
+    *reinterpret_cast<void **>(&LINK_adreno_compute_aligned_width_and_height) =
+        ::dlsym(libadreno_utils_, "compute_aligned_width_and_height");
+    *reinterpret_cast<void **>(&LINK_adreno_compute_padding) =
+        ::dlsym(libadreno_utils_, "compute_surface_padding");
+    *reinterpret_cast<void **>(&LINK_adreno_compute_compressedfmt_aligned_width_and_height) =
+        ::dlsym(libadreno_utils_, "compute_compressedfmt_aligned_width_and_height");
+    *reinterpret_cast<void **>(&LINK_adreno_isUBWCSupportedByGpu) =
+        ::dlsym(libadreno_utils_, "isUBWCSupportedByGpu");
+    *reinterpret_cast<void **>(&LINK_adreno_get_gpu_pixel_alignment) =
+        ::dlsym(libadreno_utils_, "get_gpu_pixel_alignment");
+  } else {
+    ALOGE(" Failed to load libadreno_utils.so");
+  }
+
+  // Check if the overriding property debug.gralloc.gfx_ubwc_disable
+  // that disables UBWC allocations for the graphics stack is set
+  char property[PROPERTY_VALUE_MAX];
+  property_get(DISABLE_UBWC_PROP, property, "0");
+  if (!(strncmp(property, "1", PROPERTY_VALUE_MAX)) ||
+      !(strncmp(property, "true", PROPERTY_VALUE_MAX))) {
+    gfx_ubwc_disable_ = true;
+  }
+
+  if ((property_get(MAP_FB_MEMORY_PROP, property, NULL) > 0) &&
+      (!strncmp(property, "1", PROPERTY_VALUE_MAX) ||
+       (!strncasecmp(property, "true", PROPERTY_VALUE_MAX)))) {
+    map_fb_ = true;
+  }
+}
+
+AdrenoMemInfo::~AdrenoMemInfo() {
+  if (libadreno_utils_) {
+    ::dlclose(libadreno_utils_);
+  }
+}
+
+void AdrenoMemInfo::AlignUnCompressedRGB(int width, int height, int format, int tile_enabled,
+                                         unsigned int *aligned_w, unsigned int *aligned_h) {
+  *aligned_w = (unsigned int)ALIGN(width, 32);
+  *aligned_h = (unsigned int)ALIGN(height, 32);
+
+  // Don't add any additional padding if debug.gralloc.map_fb_memory
+  // is enabled
+  if (map_fb_) {
+    return;
+  }
+
+  int bpp = 4;
+  switch (format) {
+    case HAL_PIXEL_FORMAT_RGB_888:
+    case HAL_PIXEL_FORMAT_BGR_888:
+      bpp = 3;
+      break;
+    case HAL_PIXEL_FORMAT_RGB_565:
+    case HAL_PIXEL_FORMAT_BGR_565:
+    case HAL_PIXEL_FORMAT_RGBA_5551:
+    case HAL_PIXEL_FORMAT_RGBA_4444:
+      bpp = 2;
+      break;
+    default:
+      break;
+  }
+
+  int raster_mode = 0;          // Adreno unknown raster mode.
+  int padding_threshold = 512;  // Threshold for padding surfaces.
+  // the function below computes aligned width and aligned height
+  // based on linear or macro tile mode selected.
+  if (LINK_adreno_compute_aligned_width_and_height) {
+    LINK_adreno_compute_aligned_width_and_height(
+        width, height, bpp, tile_enabled, raster_mode, padding_threshold,
+        reinterpret_cast<int *>(aligned_w), reinterpret_cast<int *>(aligned_h));
+  } else if (LINK_adreno_compute_padding) {
+    int surface_tile_height = 1;  // Linear surface
+    *aligned_w = UINT(LINK_adreno_compute_padding(width, bpp, surface_tile_height, raster_mode,
+                                                  padding_threshold));
+    ALOGW("%s: Warning!! Old GFX API is used to calculate stride", __FUNCTION__);
+  } else {
+    ALOGW(
+        "%s: Warning!! Symbols compute_surface_padding and "
+        "compute_aligned_width_and_height not found",
+        __FUNCTION__);
+  }
+}
+
+void AdrenoMemInfo::AlignCompressedRGB(int width, int height, int format, unsigned int *aligned_w,
+                                       unsigned int *aligned_h) {
+  if (LINK_adreno_compute_compressedfmt_aligned_width_and_height) {
+    int bytesPerPixel = 0;
+    int raster_mode = 0;          // Adreno unknown raster mode.
+    int padding_threshold = 512;  // Threshold for padding
+    // surfaces.
+
+    LINK_adreno_compute_compressedfmt_aligned_width_and_height(
+        width, height, format, 0, raster_mode, padding_threshold,
+        reinterpret_cast<int *>(aligned_w), reinterpret_cast<int *>(aligned_h), &bytesPerPixel);
+  } else {
+    *aligned_w = (unsigned int)ALIGN(width, 32);
+    *aligned_h = (unsigned int)ALIGN(height, 32);
+    ALOGW("%s: Warning!! compute_compressedfmt_aligned_width_and_height not found", __FUNCTION__);
+  }
+}
+
+bool AdrenoMemInfo::IsUBWCSupportedByGPU(int format) {
+  if (!gfx_ubwc_disable_ && LINK_adreno_isUBWCSupportedByGpu) {
+    ADRENOPIXELFORMAT gpu_format = GetGpuPixelFormat(format);
+    return LINK_adreno_isUBWCSupportedByGpu(gpu_format);
+  }
+
+  return false;
+}
+
+uint32_t AdrenoMemInfo::GetGpuPixelAlignment() {
+  if (LINK_adreno_get_gpu_pixel_alignment) {
+    return LINK_adreno_get_gpu_pixel_alignment();
+  }
+
+  return 1;
+}
+
+ADRENOPIXELFORMAT AdrenoMemInfo::GetGpuPixelFormat(int hal_format) {
+  switch (hal_format) {
+    case HAL_PIXEL_FORMAT_RGBA_8888:
+      return ADRENO_PIXELFORMAT_R8G8B8A8;
+    case HAL_PIXEL_FORMAT_RGBX_8888:
+      return ADRENO_PIXELFORMAT_R8G8B8X8;
+    case HAL_PIXEL_FORMAT_RGB_565:
+      return ADRENO_PIXELFORMAT_B5G6R5;
+    case HAL_PIXEL_FORMAT_BGR_565:
+      return ADRENO_PIXELFORMAT_R5G6B5;
+    case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:
+      return ADRENO_PIXELFORMAT_NV12;
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC:
+      return ADRENO_PIXELFORMAT_NV12_EXT;
+    case HAL_PIXEL_FORMAT_YCbCr_420_TP10_UBWC:
+      return ADRENO_PIXELFORMAT_TP10;
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010:
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010_UBWC:
+      return ADRENO_PIXELFORMAT_P010;
+    case HAL_PIXEL_FORMAT_RGBA_1010102:
+       return ADRENO_PIXELFORMAT_R10G10B10A2_UNORM;
+    case HAL_PIXEL_FORMAT_RGBX_1010102:
+       return ADRENO_PIXELFORMAT_R10G10B10X2_UNORM;
+    case HAL_PIXEL_FORMAT_ABGR_2101010:
+       return ADRENO_PIXELFORMAT_A2B10G10R10_UNORM;
+    case HAL_PIXEL_FORMAT_RGB_888:
+       return ADRENO_PIXELFORMAT_R8G8B8;
+    default:
+      ALOGE("%s: No map for format: 0x%x", __FUNCTION__, hal_format);
+      break;
+  }
+
+  return ADRENO_PIXELFORMAT_UNKNOWN;
+}
+
+}  // namespace gralloc1

--- a/gralloc1/gr_adreno_info.h
+++ b/gralloc1/gr_adreno_info.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2011-2017, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GR_ADRENO_INFO_H__
+#define __GR_ADRENO_INFO_H__
+
+#include <media/msm_media_info.h>
+
+namespace gralloc1 {
+
+// Adreno Pixel Formats
+typedef enum {
+  ADRENO_PIXELFORMAT_UNKNOWN = 0,
+  ADRENO_PIXELFORMAT_R10G10B10A2_UNORM = 24,  // Vertex, Normalized GL_UNSIGNED_INT_10_10_10_2_OES
+  ADRENO_PIXELFORMAT_R8G8B8A8 = 28,
+  ADRENO_PIXELFORMAT_R8G8B8A8_SRGB = 29,
+  ADRENO_PIXELFORMAT_B5G6R5 = 85,
+  ADRENO_PIXELFORMAT_B5G5R5A1 = 86,
+  ADRENO_PIXELFORMAT_B8G8R8A8 = 90,
+  ADRENO_PIXELFORMAT_B8G8R8A8_SRGB = 91,
+  ADRENO_PIXELFORMAT_B8G8R8X8_SRGB = 93,
+  ADRENO_PIXELFORMAT_NV12 = 103,
+  ADRENO_PIXELFORMAT_P010 = 104,
+  ADRENO_PIXELFORMAT_YUY2 = 107,
+  ADRENO_PIXELFORMAT_B4G4R4A4 = 115,
+  ADRENO_PIXELFORMAT_NV12_EXT = 506,       // NV12 with non-std alignment and offsets
+  ADRENO_PIXELFORMAT_R8G8B8X8 = 507,       //  GL_RGB8 (Internal)
+  ADRENO_PIXELFORMAT_R8G8B8 = 508,         //  GL_RGB8
+  ADRENO_PIXELFORMAT_A1B5G5R5 = 519,       //  GL_RGB5_A1
+  ADRENO_PIXELFORMAT_R8G8B8X8_SRGB = 520,  //  GL_SRGB8
+  ADRENO_PIXELFORMAT_R8G8B8_SRGB = 521,    //  GL_SRGB8
+  ADRENO_PIXELFORMAT_A2B10G10R10_UNORM = 532,
+                                          // Vertex, Normalized GL_UNSIGNED_INT_10_10_10_2_OES
+  ADRENO_PIXELFORMAT_R10G10B10X2_UNORM = 537,
+                                          // Vertex, Normalized GL_UNSIGNED_INT_10_10_10_2_OES
+  ADRENO_PIXELFORMAT_R5G6B5 = 610,         //  RGBA version of B5G6R5
+  ADRENO_PIXELFORMAT_R5G5B5A1 = 611,       //  RGBA version of B5G5R5A1
+  ADRENO_PIXELFORMAT_R4G4B4A4 = 612,       //  RGBA version of B4G4R4A4
+  ADRENO_PIXELFORMAT_UYVY = 614,           //  YUV 4:2:2 packed progressive (1 plane)
+  ADRENO_PIXELFORMAT_NV21 = 619,
+  ADRENO_PIXELFORMAT_Y8U8V8A8 = 620,  // YUV 4:4:4 packed (1 plane)
+  ADRENO_PIXELFORMAT_Y8 = 625,        //  Single 8-bit luma only channel YUV format
+  ADRENO_PIXELFORMAT_TP10 = 648,      // YUV 4:2:0 planar 10 bits/comp (2 planes)
+} ADRENOPIXELFORMAT;
+
+class AdrenoMemInfo {
+ public:
+  /*
+   * Function to compute aligned width and aligned height based on
+   * width, height, format and usage flags.
+   *
+   * @return aligned width, aligned height
+   */
+  void GetAlignedWidthAndHeight(int width, int height, int format, int usage,
+                                unsigned int *aligned_w, unsigned int *aligned_h, bool ubwc_enabled,
+                                bool tile_enabled);
+
+  /*
+   * Function to compute the adreno aligned width and aligned height
+   * based on the width and format.
+   *
+   * @return aligned width, aligned height
+   */
+  void AlignUnCompressedRGB(int width, int height, int format, int tileEnabled,
+                            unsigned int *aligned_w, unsigned int *aligned_h);
+
+  /*
+   * Function to compute the adreno aligned width and aligned height
+   * based on the width and format.
+   *
+   * @return aligned width, aligned height
+   */
+  void AlignCompressedRGB(int width, int height, int format, unsigned int *aligned_w,
+                          unsigned int *aligned_h);
+
+  /*
+   * Function to compute the pixel alignment requirement.
+   *
+   * @return alignment
+   */
+  uint32_t GetGpuPixelAlignment();
+
+  /*
+   * Function to query whether GPU supports UBWC for given HAL format
+   * @return > 0 : supported
+   *           0 : not supported
+   */
+  bool IsUBWCSupportedByGPU(int format);
+
+  /*
+   * Function to get the corresponding Adreno format for given HAL format
+   */
+  ADRENOPIXELFORMAT GetGpuPixelFormat(int hal_format);
+
+  static AdrenoMemInfo *GetInstance();
+
+ private:
+  AdrenoMemInfo();
+  ~AdrenoMemInfo();
+  // link(s)to adreno surface padding library.
+  int (*LINK_adreno_compute_padding)(int width, int bpp, int surface_tile_height,
+                                     int screen_tile_height, int padding_threshold) = NULL;
+  void (*LINK_adreno_compute_aligned_width_and_height)(int width, int height, int bpp,
+                                                       int tile_mode, int raster_mode,
+                                                       int padding_threshold, int *aligned_w,
+                                                       int *aligned_h) = NULL;
+  void (*LINK_adreno_compute_compressedfmt_aligned_width_and_height)(
+      int width, int height, int format, int tile_mode, int raster_mode, int padding_threshold,
+      int *aligned_w, int *aligned_h, int *bpp) = NULL;
+  int (*LINK_adreno_isUBWCSupportedByGpu)(ADRENOPIXELFORMAT format) = NULL;
+  unsigned int (*LINK_adreno_get_gpu_pixel_alignment)() = NULL;
+
+  bool gfx_ubwc_disable_ = false;
+  bool map_fb_ = false;
+  void *libadreno_utils_ = NULL;
+
+  static AdrenoMemInfo *s_instance;
+};
+
+}  // namespace gralloc1
+
+#endif  // __GR_ADRENO_INFO_H__

--- a/gralloc1/gr_allocator.cpp
+++ b/gralloc1/gr_allocator.cpp
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2011-2018, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <log/log.h>
+#include <algorithm>
+#include <vector>
+
+#include "gr_utils.h"
+#include "gr_allocator.h"
+#include "gralloc_priv.h"
+
+#include "qd_utils.h"
+
+#ifndef ION_FLAG_CP_PIXEL
+#define ION_FLAG_CP_PIXEL 0
+#endif
+
+#ifndef ION_FLAG_ALLOW_NON_CONTIG
+#define ION_FLAG_ALLOW_NON_CONTIG 0
+#endif
+
+#ifndef ION_FLAG_CP_CAMERA_PREVIEW
+#define ION_FLAG_CP_CAMERA_PREVIEW 0
+#endif
+
+#ifdef MASTER_SIDE_CP
+#define CP_HEAP_ID ION_SECURE_HEAP_ID
+#define SD_HEAP_ID ION_SECURE_DISPLAY_HEAP_ID
+#define ION_CP_FLAGS (ION_SECURE | ION_FLAG_CP_PIXEL)
+#define ION_SD_FLAGS (ION_SECURE | ION_FLAG_CP_SEC_DISPLAY)
+#define ION_SC_FLAGS (ION_SECURE | ION_FLAG_CP_CAMERA)
+#define ION_SC_PREVIEW_FLAGS (ION_SECURE | ION_FLAG_CP_CAMERA_PREVIEW)
+#else  // SLAVE_SIDE_CP
+#define CP_HEAP_ID ION_CP_MM_HEAP_ID
+#ifdef USE_SECURE_HEAP
+#define SD_HEAP_ID ION_SECURE_DISPLAY_HEAP_ID
+#else
+#define SD_HEAP_ID ION_CP_MM_HEAP_ID
+#endif
+#define ION_CP_FLAGS (ION_SECURE | ION_FLAG_ALLOW_NON_CONTIG)
+#define ION_SD_FLAGS ION_SECURE
+#define ION_SC_FLAGS ION_SECURE
+#define ION_SC_PREVIEW_FLAGS ION_SECURE
+#endif
+
+using std::vector;
+using std::shared_ptr;
+
+namespace gralloc1 {
+
+static BufferInfo GetBufferInfo(const BufferDescriptor &descriptor) {
+  return BufferInfo(descriptor.GetWidth(), descriptor.GetHeight(), descriptor.GetFormat(),
+                    descriptor.GetProducerUsage(), descriptor.GetConsumerUsage());
+}
+
+Allocator::Allocator() : ion_allocator_(NULL) {
+}
+
+bool Allocator::Init() {
+  ion_allocator_ = new IonAlloc();
+  if (!ion_allocator_->Init()) {
+    return false;
+  }
+
+  return true;
+}
+
+Allocator::~Allocator() {
+  if (ion_allocator_) {
+    delete ion_allocator_;
+  }
+}
+
+int Allocator::AllocateMem(AllocData *alloc_data, gralloc1_producer_usage_t prod_usage,
+                           gralloc1_consumer_usage_t cons_usage) {
+  int ret;
+  alloc_data->uncached = UseUncached(prod_usage, cons_usage);
+
+  // After this point we should have the right heap set, there is no fallback
+  GetIonHeapInfo(prod_usage, cons_usage, &alloc_data->heap_id, &alloc_data->alloc_type,
+                 &alloc_data->flags);
+
+  ret = ion_allocator_->AllocBuffer(alloc_data);
+  if (ret >= 0) {
+    alloc_data->alloc_type |= private_handle_t::PRIV_FLAGS_USES_ION;
+  } else {
+    ALOGE("%s: Failed to allocate buffer - heap: 0x%x flags: 0x%x", __FUNCTION__,
+          alloc_data->heap_id, alloc_data->flags);
+  }
+
+  return ret;
+}
+
+int Allocator::MapBuffer(void **base, unsigned int size, unsigned int offset, int fd) {
+  if (ion_allocator_) {
+    return ion_allocator_->MapBuffer(base, size, offset, fd);
+  }
+
+  return -EINVAL;
+}
+
+int Allocator::ImportBuffer(int fd) {
+  if (ion_allocator_) {
+    return ion_allocator_->ImportBuffer(fd);
+  }
+  return -EINVAL;
+}
+
+int Allocator::FreeBuffer(void *base, unsigned int size, unsigned int offset, int fd,
+                          int handle) {
+  if (ion_allocator_) {
+    return ion_allocator_->FreeBuffer(base, size, offset, fd, handle);
+  }
+
+  return -EINVAL;
+}
+
+int Allocator::CleanBuffer(void *base, unsigned int size, unsigned int offset, int handle, int op) {
+  if (ion_allocator_) {
+    return ion_allocator_->CleanBuffer(base, size, offset, handle, op);
+  }
+
+  return -EINVAL;
+}
+
+bool Allocator::CheckForBufferSharing(uint32_t num_descriptors,
+                                      const vector<shared_ptr<BufferDescriptor>>& descriptors,
+                                      ssize_t *max_index) {
+  unsigned int cur_heap_id = 0, prev_heap_id = 0;
+  unsigned int cur_alloc_type = 0, prev_alloc_type = 0;
+  unsigned int cur_ion_flags = 0, prev_ion_flags = 0;
+  bool cur_uncached = false, prev_uncached = false;
+  unsigned int alignedw, alignedh;
+  unsigned int max_size = 0;
+
+  *max_index = -1;
+  for (uint32_t i = 0; i < num_descriptors; i++) {
+    // Check Cached vs non-cached and all the ION flags
+    cur_uncached = UseUncached(descriptors[i]->GetProducerUsage(),
+                               descriptors[i]->GetConsumerUsage());
+    GetIonHeapInfo(descriptors[i]->GetProducerUsage(), descriptors[i]->GetConsumerUsage(),
+                   &cur_heap_id, &cur_alloc_type, &cur_ion_flags);
+
+    if (i > 0 && (cur_heap_id != prev_heap_id || cur_alloc_type != prev_alloc_type ||
+                  cur_ion_flags != prev_ion_flags)) {
+      return false;
+    }
+
+    // For same format type, find the descriptor with bigger size
+    GetAlignedWidthAndHeight(GetBufferInfo(*descriptors[i]), &alignedw, &alignedh);
+    unsigned int size = GetSize(GetBufferInfo(*descriptors[i]), alignedw, alignedh);
+    if (max_size < size) {
+      *max_index = INT(i);
+      max_size = size;
+    }
+
+    prev_heap_id = cur_heap_id;
+    prev_uncached = cur_uncached;
+    prev_ion_flags = cur_ion_flags;
+    prev_alloc_type = cur_alloc_type;
+  }
+
+  return true;
+}
+
+int Allocator::GetImplDefinedFormat(gralloc1_producer_usage_t prod_usage,
+                                    gralloc1_consumer_usage_t cons_usage, int format) {
+  int gr_format = format;
+
+  // If input format is HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED then based on
+  // the usage bits, gralloc assigns a format.
+  if (format == HAL_PIXEL_FORMAT_IMPLEMENTATION_DEFINED ||
+      format == HAL_PIXEL_FORMAT_YCbCr_420_888) {
+    if (prod_usage & GRALLOC1_PRODUCER_USAGE_PRIVATE_ALLOC_UBWC) {
+      gr_format = HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC;
+    } else if (cons_usage & GRALLOC1_CONSUMER_USAGE_VIDEO_ENCODER) {
+      gr_format = HAL_PIXEL_FORMAT_NV12_ENCODEABLE;  // NV12
+    } else if (cons_usage & GRALLOC1_CONSUMER_USAGE_CAMERA) {
+      if (prod_usage & GRALLOC1_PRODUCER_USAGE_CAMERA) {
+        // Assumed ZSL if both producer and consumer camera flags set
+        gr_format = HAL_PIXEL_FORMAT_NV21_ZSL;  // NV21
+      } else {
+        gr_format = HAL_PIXEL_FORMAT_YCrCb_420_SP;  // NV21
+      }
+    } else if (prod_usage & GRALLOC1_PRODUCER_USAGE_CAMERA) {
+      if (format == HAL_PIXEL_FORMAT_YCbCr_420_888) {
+        gr_format = HAL_PIXEL_FORMAT_NV21_ZSL;  // NV21
+      } else {
+        gr_format = HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS;  // NV12 preview
+      }
+    } else if (cons_usage & GRALLOC1_CONSUMER_USAGE_HWCOMPOSER) {
+      // XXX: If we still haven't set a format, default to RGBA8888
+      gr_format = HAL_PIXEL_FORMAT_RGBA_8888;
+    } else if (format == HAL_PIXEL_FORMAT_YCbCr_420_888) {
+      // If no other usage flags are detected, default the
+      // flexible YUV format to NV21_ZSL
+      gr_format = HAL_PIXEL_FORMAT_NV21_ZSL;
+    }
+  }
+
+  return gr_format;
+}
+
+/* The default policy is to return cached buffers unless the client explicity
+ * sets the PRIVATE_UNCACHED flag or indicates that the buffer will be rarely
+ * read or written in software. */
+bool Allocator::UseUncached(gralloc1_producer_usage_t prod_usage,
+                            gralloc1_consumer_usage_t cons_usage) {
+  if ((prod_usage & GRALLOC1_PRODUCER_USAGE_PRIVATE_UNCACHED) ||
+      (prod_usage & GRALLOC1_PRODUCER_USAGE_PROTECTED)) {
+    return true;
+  }
+
+  // CPU read rarely
+  if ((prod_usage & GRALLOC1_PRODUCER_USAGE_CPU_READ) &&
+      !(prod_usage & GRALLOC1_PRODUCER_USAGE_CPU_READ_OFTEN)) {
+    return true;
+  }
+
+  // CPU  write rarely
+  if ((prod_usage & GRALLOC1_PRODUCER_USAGE_CPU_WRITE) &&
+      !(prod_usage & GRALLOC1_PRODUCER_USAGE_CPU_WRITE_OFTEN)) {
+    return true;
+  }
+
+  if ((prod_usage & GRALLOC1_PRODUCER_USAGE_SENSOR_DIRECT_DATA) ||
+      (cons_usage & GRALLOC1_CONSUMER_USAGE_GPU_DATA_BUFFER)) {
+    return true;
+  }
+
+  return false;
+}
+
+void Allocator::GetIonHeapInfo(gralloc1_producer_usage_t prod_usage,
+                               gralloc1_consumer_usage_t cons_usage, unsigned int *ion_heap_id,
+                               unsigned int *alloc_type, unsigned int *ion_flags) {
+  unsigned int heap_id = 0;
+  unsigned int type = 0;
+  uint32_t flags = 0;
+  if (prod_usage & GRALLOC1_PRODUCER_USAGE_PROTECTED) {
+    if (cons_usage & GRALLOC1_CONSUMER_USAGE_PRIVATE_SECURE_DISPLAY) {
+      heap_id = ION_HEAP(SD_HEAP_ID);
+      /*
+       * There is currently no flag in ION for Secure Display
+       * VM. Please add it to the define once available.
+       */
+      flags |= UINT(ION_SD_FLAGS);
+    } else if (prod_usage & GRALLOC1_PRODUCER_USAGE_CAMERA) {
+      heap_id = ION_HEAP(SD_HEAP_ID);
+      if (cons_usage & GRALLOC1_CONSUMER_USAGE_HWCOMPOSER) {
+        flags |= UINT(ION_SC_PREVIEW_FLAGS);
+      } else {
+        flags |= UINT(ION_SC_FLAGS);
+      }
+    } else {
+      heap_id = ION_HEAP(CP_HEAP_ID);
+      flags |= UINT(ION_CP_FLAGS);
+    }
+  } else if (prod_usage & GRALLOC1_PRODUCER_USAGE_PRIVATE_MM_HEAP) {
+    // MM Heap is exclusively a secure heap.
+    // If it is used for non secure cases, fallback to IOMMU heap
+    ALOGW("MM_HEAP cannot be used as an insecure heap. Using system heap instead!!");
+    heap_id |= ION_HEAP(ION_SYSTEM_HEAP_ID);
+  }
+
+  if (prod_usage & GRALLOC1_PRODUCER_USAGE_PRIVATE_CAMERA_HEAP) {
+    heap_id |= ION_HEAP(ION_CAMERA_HEAP_ID);
+  }
+
+  if (prod_usage & GRALLOC1_PRODUCER_USAGE_PRIVATE_ADSP_HEAP ||
+      prod_usage & GRALLOC1_PRODUCER_USAGE_SENSOR_DIRECT_DATA) {
+    heap_id |= ION_HEAP(ION_ADSP_HEAP_ID);
+  }
+
+  if (flags & UINT(ION_SECURE)) {
+    type |= private_handle_t::PRIV_FLAGS_SECURE_BUFFER;
+  }
+
+  // if no ion heap flags are set, default to system heap
+  if (!heap_id) {
+    heap_id = ION_HEAP(ION_SYSTEM_HEAP_ID);
+  }
+
+  *alloc_type = type;
+  *ion_flags = flags;
+  *ion_heap_id = heap_id;
+
+  return;
+}
+}  // namespace gralloc1

--- a/gralloc1/gr_allocator.h
+++ b/gralloc1/gr_allocator.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2011-2017, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GR_ALLOCATOR_H__
+#define __GR_ALLOCATOR_H__
+
+#ifdef MASTER_SIDE_CP
+#define SECURE_ALIGN SZ_4K
+#else
+#define SECURE_ALIGN SZ_1M
+#endif
+
+#include <vector>
+
+#include "gralloc_priv.h"
+#include "gr_buf_descriptor.h"
+#include "gr_ion_alloc.h"
+
+namespace gralloc1 {
+
+class Allocator {
+ public:
+  Allocator();
+  ~Allocator();
+  bool Init();
+  int MapBuffer(void **base, unsigned int size, unsigned int offset, int fd);
+  int ImportBuffer(int fd);
+  int FreeBuffer(void *base, unsigned int size, unsigned int offset, int fd, int handle);
+  int CleanBuffer(void *base, unsigned int size, unsigned int offset, int handle, int op);
+  int AllocateMem(AllocData *data, gralloc1_producer_usage_t prod_usage,
+                  gralloc1_consumer_usage_t cons_usage);
+  // @return : index of the descriptor with maximum buffer size req
+  bool CheckForBufferSharing(uint32_t num_descriptors,
+                             const std::vector<std::shared_ptr<BufferDescriptor>>& descriptors,
+                             ssize_t *max_index);
+  int GetImplDefinedFormat(gralloc1_producer_usage_t prod_usage,
+                           gralloc1_consumer_usage_t cons_usage, int format);
+  bool UseUncached(gralloc1_producer_usage_t prod_usage, gralloc1_consumer_usage_t cons_usage);
+
+ private:
+  void GetIonHeapInfo(gralloc1_producer_usage_t prod_usage, gralloc1_consumer_usage_t cons_usage,
+                      unsigned int *ion_heap_id, unsigned int *alloc_type, unsigned int *ion_flags);
+
+  IonAlloc *ion_allocator_ = NULL;
+};
+
+}  // namespace gralloc1
+
+#endif  // __GR_ALLOCATOR_H__

--- a/gralloc1/gr_buf_descriptor.h
+++ b/gralloc1/gr_buf_descriptor.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2016-2017, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GR_BUF_DESCRIPTOR_H__
+#define __GR_BUF_DESCRIPTOR_H__
+
+#include <hardware/gralloc1.h>
+#include <atomic>
+
+namespace gralloc1 {
+class BufferDescriptor {
+ public:
+  BufferDescriptor() : id_(next_id_++) {}
+
+  BufferDescriptor(int w, int h, int f)
+      : width_(w),
+        height_(h),
+        format_(f),
+        producer_usage_(GRALLOC1_PRODUCER_USAGE_NONE),
+        consumer_usage_(GRALLOC1_CONSUMER_USAGE_NONE),
+        id_(next_id_++) {}
+
+  BufferDescriptor(int w, int h, int f, gralloc1_producer_usage_t prod_usage,
+                   gralloc1_consumer_usage_t cons_usage)
+      : width_(w),
+        height_(h),
+        format_(f),
+        producer_usage_(prod_usage),
+        consumer_usage_(cons_usage),
+        id_(next_id_++) {}
+
+  void SetConsumerUsage(gralloc1_consumer_usage_t usage) { consumer_usage_ = usage; }
+
+  void SetProducerUsage(gralloc1_producer_usage_t usage) { producer_usage_ = usage; }
+
+  void SetDimensions(int w, int h) {
+    width_ = w;
+    height_ = h;
+  }
+
+  void SetColorFormat(int format) { format_ = format; }
+
+  void SetLayerCount(uint32_t layer_count) { layer_count_ = layer_count; }
+
+  gralloc1_consumer_usage_t GetConsumerUsage() const { return consumer_usage_; }
+
+  gralloc1_producer_usage_t GetProducerUsage() const { return producer_usage_; }
+
+  int GetWidth() const { return width_; }
+
+  int GetHeight() const { return height_; }
+
+  int GetFormat() const { return format_; }
+
+  uint32_t GetLayerCount() const { return layer_count_; }
+
+  gralloc1_buffer_descriptor_t GetId() const { return id_; }
+
+ private:
+  int width_ = -1;
+  int height_ = -1;
+  int format_ = -1;
+  uint32_t layer_count_ = 1;
+  gralloc1_producer_usage_t producer_usage_ = GRALLOC1_PRODUCER_USAGE_NONE;
+  gralloc1_consumer_usage_t consumer_usage_ = GRALLOC1_CONSUMER_USAGE_NONE;
+  const gralloc1_buffer_descriptor_t id_;
+  static std::atomic<gralloc1_buffer_descriptor_t> next_id_;
+};
+};  // namespace gralloc1
+#endif  // __GR_BUF_DESCRIPTOR_H__

--- a/gralloc1/gr_buf_mgr.cpp
+++ b/gralloc1/gr_buf_mgr.cpp
@@ -1,0 +1,930 @@
+/*
+ * Copyright (c) 2011-2018 The Linux Foundation. All rights reserved.
+ * Not a Contribution
+ *
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define DEBUG 0
+
+#include <iomanip>
+#include <utility>
+#include <vector>
+#include <sstream>
+
+#include "qd_utils.h"
+#include "gr_priv_handle.h"
+#include "gr_buf_descriptor.h"
+#include "gr_utils.h"
+#include "gr_buf_mgr.h"
+#include "qdMetaData.h"
+
+namespace gralloc1 {
+std::atomic<gralloc1_buffer_descriptor_t> BufferDescriptor::next_id_(1);
+
+static BufferInfo GetBufferInfo(const BufferDescriptor &descriptor) {
+  return BufferInfo(descriptor.GetWidth(), descriptor.GetHeight(), descriptor.GetFormat(),
+                    descriptor.GetProducerUsage(), descriptor.GetConsumerUsage());
+}
+
+BufferManager::BufferManager() : next_id_(0) {
+  char property[PROPERTY_VALUE_MAX];
+
+  // Map framebuffer memory
+  if ((property_get(MAP_FB_MEMORY_PROP, property, NULL) > 0) &&
+      (!strncmp(property, "1", PROPERTY_VALUE_MAX) ||
+       (!strncasecmp(property, "true", PROPERTY_VALUE_MAX)))) {
+    map_fb_mem_ = true;
+  }
+
+  handles_map_.clear();
+  allocator_ = new Allocator();
+  allocator_->Init();
+}
+
+
+gralloc1_error_t BufferManager::CreateBufferDescriptor(
+    gralloc1_buffer_descriptor_t *descriptor_id) {
+  std::lock_guard<std::mutex> lock(descriptor_lock_);
+  auto descriptor = std::make_shared<BufferDescriptor>();
+  descriptors_map_.emplace(descriptor->GetId(), descriptor);
+  *descriptor_id = descriptor->GetId();
+  return GRALLOC1_ERROR_NONE;
+}
+
+gralloc1_error_t BufferManager::DestroyBufferDescriptor(
+    gralloc1_buffer_descriptor_t descriptor_id) {
+  std::lock_guard<std::mutex> lock(descriptor_lock_);
+  const auto descriptor = descriptors_map_.find(descriptor_id);
+  if (descriptor == descriptors_map_.end()) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  }
+  descriptors_map_.erase(descriptor);
+  return GRALLOC1_ERROR_NONE;
+}
+
+BufferManager::~BufferManager() {
+  if (allocator_) {
+    delete allocator_;
+  }
+}
+
+gralloc1_error_t BufferManager::AllocateBuffers(uint32_t num_descriptors,
+                                                const gralloc1_buffer_descriptor_t *descriptor_ids,
+                                                buffer_handle_t *out_buffers) {
+  bool shared = true;
+  gralloc1_error_t status = GRALLOC1_ERROR_NONE;
+
+  // since GRALLOC1_CAPABILITY_TEST_ALLOCATE capability is supported
+  // client can ask to test the allocation by passing NULL out_buffers
+  bool test_allocate = !out_buffers;
+
+  // Validate descriptors
+  std::lock_guard<std::mutex> descriptor_lock(descriptor_lock_);
+  std::vector<std::shared_ptr<BufferDescriptor>> descriptors;
+  for (uint32_t i = 0; i < num_descriptors; i++) {
+    const auto map_descriptor = descriptors_map_.find(descriptor_ids[i]);
+    if (map_descriptor == descriptors_map_.end()) {
+      return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+    } else {
+      descriptors.push_back(map_descriptor->second);
+    }
+  }
+
+  //  Resolve implementation defined formats
+  for (auto &descriptor : descriptors) {
+    descriptor->SetColorFormat(allocator_->GetImplDefinedFormat(descriptor->GetProducerUsage(),
+                                                                descriptor->GetConsumerUsage(),
+                                                                descriptor->GetFormat()));
+  }
+
+  // Check if input descriptors can be supported AND
+  // Find out if a single buffer can be shared for all the given input descriptors
+  uint32_t i = 0;
+  ssize_t max_buf_index = -1;
+  shared = allocator_->CheckForBufferSharing(num_descriptors, descriptors, &max_buf_index);
+
+  if (test_allocate) {
+    status = shared ? GRALLOC1_ERROR_NOT_SHARED : status;
+    return status;
+  }
+
+  std::lock_guard<std::mutex> buffer_lock(buffer_lock_);
+  if (shared && (max_buf_index >= 0)) {
+    // Allocate one and duplicate/copy the handles for each descriptor
+    if (AllocateBuffer(*descriptors[UINT(max_buf_index)], &out_buffers[max_buf_index])) {
+      return GRALLOC1_ERROR_NO_RESOURCES;
+    }
+
+    for (i = 0; i < num_descriptors; i++) {
+      // Create new handle for a given descriptor.
+      // Current assumption is even MetaData memory would be same
+      // Need to revisit if there is a need for own metadata memory
+      if (i != UINT(max_buf_index)) {
+        CreateSharedHandle(out_buffers[max_buf_index], *descriptors[i], &out_buffers[i]);
+      }
+    }
+  } else {
+    // Buffer sharing is not feasible.
+    // Allocate separate buffer for each descriptor
+    for (i = 0; i < num_descriptors; i++) {
+      if (AllocateBuffer(*descriptors[i], &out_buffers[i])) {
+        return GRALLOC1_ERROR_NO_RESOURCES;
+      }
+    }
+  }
+
+  // Allocation is successful. If backstore is not shared inform the client.
+  if (!shared) {
+    return GRALLOC1_ERROR_NOT_SHARED;
+  }
+
+  return status;
+}
+
+void BufferManager::CreateSharedHandle(buffer_handle_t inbuffer, const BufferDescriptor &descriptor,
+                                       buffer_handle_t *outbuffer) {
+  // TODO(user): This path is not verified
+  private_handle_t const *input = reinterpret_cast<private_handle_t const *>(inbuffer);
+
+  // Get Buffer attributes or dimension
+  unsigned int alignedw = 0, alignedh = 0;
+  BufferInfo info = GetBufferInfo(descriptor);
+
+  GetAlignedWidthAndHeight(info, &alignedw, &alignedh);
+
+  // create new handle from input reference handle and given descriptor
+  int flags = GetHandleFlags(descriptor.GetFormat(), descriptor.GetProducerUsage(),
+                             descriptor.GetConsumerUsage());
+  int buffer_type = GetBufferType(descriptor.GetFormat());
+
+  // Duplicate the fds
+  // TODO(user): Not sure what to do for fb_id. Use duped fd and new dimensions?
+  private_handle_t *out_hnd = new private_handle_t(dup(input->fd),
+                                                   dup(input->fd_metadata),
+                                                   flags,
+                                                   INT(alignedw),
+                                                   INT(alignedh),
+                                                   descriptor.GetWidth(),
+                                                   descriptor.GetHeight(),
+                                                   descriptor.GetFormat(),
+                                                   buffer_type,
+                                                   input->size,
+                                                   descriptor.GetProducerUsage(),
+                                                   descriptor.GetConsumerUsage());
+  out_hnd->id = ++next_id_;
+  // TODO(user): Base address of shared handle and ion handles
+  RegisterHandleLocked(out_hnd, -1, -1);
+  *outbuffer = out_hnd;
+}
+
+gralloc1_error_t BufferManager::FreeBuffer(std::shared_ptr<Buffer> buf) {
+  auto hnd = buf->handle;
+  ALOGD_IF(DEBUG, "FreeBuffer handle:%p", hnd);
+
+  if (private_handle_t::validate(hnd) != 0) {
+    ALOGE("FreeBuffer: Invalid handle: %p", hnd);
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+
+  if (allocator_->FreeBuffer(reinterpret_cast<void *>(hnd->base), hnd->size, hnd->offset,
+                             hnd->fd, buf->ion_handle_main) != 0) {
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+
+  unsigned int meta_size = ALIGN((unsigned int)sizeof(MetaData_t), PAGE_SIZE);
+  if (allocator_->FreeBuffer(reinterpret_cast<void *>(hnd->base_metadata), meta_size,
+                             hnd->offset_metadata, hnd->fd_metadata, buf->ion_handle_meta) != 0) {
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+
+  private_handle_t * handle = const_cast<private_handle_t *>(hnd);
+  handle->fd = -1;
+  handle->fd_metadata = -1;
+  if (!(handle->flags & private_handle_t::PRIV_FLAGS_CLIENT_ALLOCATED)) {
+      delete handle;
+  }
+  return GRALLOC1_ERROR_NONE;
+}
+
+void BufferManager::RegisterHandleLocked(const private_handle_t *hnd,
+                                         int ion_handle,
+                                         int ion_handle_meta) {
+  auto buffer = std::make_shared<Buffer>(hnd, ion_handle, ion_handle_meta);
+  handles_map_.emplace(std::make_pair(hnd, buffer));
+}
+
+gralloc1_error_t BufferManager::ImportHandleLocked(private_handle_t *hnd) {
+  ALOGD_IF(DEBUG, "Importing handle:%p id: %" PRIu64, hnd, hnd->id);
+  int ion_handle = allocator_->ImportBuffer(hnd->fd);
+  if (ion_handle < 0) {
+    ALOGE("Failed to import ion buffer: hnd: %p, fd:%d, id:%" PRIu64, hnd, hnd->fd, hnd->id);
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+  int ion_handle_meta = allocator_->ImportBuffer(hnd->fd_metadata);
+  if (ion_handle_meta < 0) {
+    ALOGE("Failed to import ion metadata buffer: hnd: %p, fd:%d, id:%" PRIu64, hnd,
+          hnd->fd, hnd->id);
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+  // Set base pointers to NULL since the data here was received over binder
+  hnd->base = 0;
+  hnd->base_metadata = 0;
+  RegisterHandleLocked(hnd, ion_handle, ion_handle_meta);
+  return GRALLOC1_ERROR_NONE;
+}
+
+std::shared_ptr<BufferManager::Buffer>
+BufferManager::GetBufferFromHandleLocked(const private_handle_t *hnd) {
+  auto it = handles_map_.find(hnd);
+  if (it != handles_map_.end()) {
+    return it->second;
+  } else {
+    return nullptr;
+  }
+}
+
+gralloc1_error_t BufferManager::MapBuffer(private_handle_t const *handle) {
+  private_handle_t *hnd = const_cast<private_handle_t *>(handle);
+  ALOGD_IF(DEBUG, "Map buffer handle:%p id: %" PRIu64, hnd, hnd->id);
+
+  hnd->base = 0;
+  if (allocator_->MapBuffer(reinterpret_cast<void **>(&hnd->base), hnd->size, hnd->offset,
+                            hnd->fd) != 0) {
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+  return GRALLOC1_ERROR_NONE;
+}
+
+gralloc1_error_t BufferManager::RetainBuffer(private_handle_t const *hnd) {
+  ALOGD_IF(DEBUG, "Retain buffer handle:%p id: %" PRIu64, hnd, hnd->id);
+  gralloc1_error_t err = GRALLOC1_ERROR_NONE;
+  std::lock_guard<std::mutex> lock(buffer_lock_);
+  auto buf = GetBufferFromHandleLocked(hnd);
+  if (buf != nullptr) {
+    buf->IncRef();
+  } else {
+    private_handle_t *handle = const_cast<private_handle_t *>(hnd);
+    err = ImportHandleLocked(handle);
+  }
+  return err;
+}
+
+gralloc1_error_t BufferManager::ReleaseBuffer(private_handle_t const *hnd) {
+  ALOGD_IF(DEBUG, "Release buffer handle:%p", hnd);
+  std::lock_guard<std::mutex> lock(buffer_lock_);
+  auto buf = GetBufferFromHandleLocked(hnd);
+  if (buf == nullptr) {
+    ALOGE("Could not find handle: %p id: %" PRIu64, hnd, hnd->id);
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  } else {
+    if (buf->DecRef()) {
+      handles_map_.erase(hnd);
+      // Unmap, close ion handle and close fd
+      FreeBuffer(buf);
+    }
+  }
+  return GRALLOC1_ERROR_NONE;
+}
+
+gralloc1_error_t BufferManager::LockBuffer(const private_handle_t *hnd,
+                                           gralloc1_producer_usage_t prod_usage,
+                                           gralloc1_consumer_usage_t cons_usage) {
+  std::lock_guard<std::mutex> lock(buffer_lock_);
+  gralloc1_error_t err = GRALLOC1_ERROR_NONE;
+  ALOGD_IF(DEBUG, "LockBuffer buffer handle:%p id: %" PRIu64, hnd, hnd->id);
+
+  // If buffer is not meant for CPU return err
+  if (!CpuCanAccess(prod_usage, cons_usage)) {
+    return GRALLOC1_ERROR_BAD_VALUE;
+  }
+
+  auto buf = GetBufferFromHandleLocked(hnd);
+  if (buf == nullptr) {
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+
+  if (hnd->base == 0) {
+    // we need to map for real
+    err = MapBuffer(hnd);
+  }
+
+  // todo use handle here
+  if (!err && (hnd->flags & private_handle_t::PRIV_FLAGS_USES_ION) &&
+      (hnd->flags & private_handle_t::PRIV_FLAGS_CACHED)) {
+
+    // Invalidate if CPU reads in software and there are non-CPU
+    // writers. No need to do this for the metadata buffer as it is
+    // only read/written in software.
+    if ((cons_usage & (GRALLOC1_CONSUMER_USAGE_CPU_READ | GRALLOC1_CONSUMER_USAGE_CPU_READ_OFTEN))
+       && (hnd->flags & private_handle_t::PRIV_FLAGS_NON_CPU_WRITER)) {
+      if (allocator_->CleanBuffer(reinterpret_cast<void *>(hnd->base), hnd->size, hnd->offset,
+                                  buf->ion_handle_main, CACHE_INVALIDATE)) {
+
+         return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+    }
+  }
+
+  // Mark the buffer to be flushed after CPU write.
+  if (!err && CpuCanWrite(prod_usage)) {
+    private_handle_t *handle = const_cast<private_handle_t *>(hnd);
+    handle->flags |= private_handle_t::PRIV_FLAGS_NEEDS_FLUSH;
+  }
+
+  return err;
+}
+
+gralloc1_error_t BufferManager::UnlockBuffer(const private_handle_t *handle) {
+  std::lock_guard<std::mutex> lock(buffer_lock_);
+  gralloc1_error_t status = GRALLOC1_ERROR_NONE;
+
+  private_handle_t *hnd = const_cast<private_handle_t *>(handle);
+  auto buf = GetBufferFromHandleLocked(hnd);
+  if (buf == nullptr) {
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+
+  if (hnd->flags & private_handle_t::PRIV_FLAGS_NEEDS_FLUSH) {
+    if (allocator_->CleanBuffer(reinterpret_cast<void *>(hnd->base), hnd->size, hnd->offset,
+                                buf->ion_handle_main, CACHE_CLEAN) != 0) {
+      status = GRALLOC1_ERROR_BAD_HANDLE;
+    }
+    hnd->flags &= ~private_handle_t::PRIV_FLAGS_NEEDS_FLUSH;
+  }
+
+  return status;
+}
+
+uint32_t BufferManager::GetDataAlignment(int format, gralloc1_producer_usage_t prod_usage,
+                                    gralloc1_consumer_usage_t cons_usage) {
+  uint32_t align = UINT(getpagesize());
+  if (format == HAL_PIXEL_FORMAT_YCbCr_420_SP_TILED) {
+    align = 8192;
+  }
+
+  if (prod_usage & GRALLOC1_PRODUCER_USAGE_PROTECTED) {
+    if ((prod_usage & GRALLOC1_PRODUCER_USAGE_CAMERA) ||
+        (cons_usage & GRALLOC1_CONSUMER_USAGE_PRIVATE_SECURE_DISPLAY)) {
+      // The alignment here reflects qsee mmu V7L/V8L requirement
+      align = SZ_2M;
+    } else {
+      align = SECURE_ALIGN;
+    }
+  }
+
+  return align;
+}
+
+int BufferManager::GetHandleFlags(int format, gralloc1_producer_usage_t prod_usage,
+                                  gralloc1_consumer_usage_t cons_usage) {
+  int flags = 0;
+  if (cons_usage & GRALLOC1_CONSUMER_USAGE_PRIVATE_EXTERNAL_ONLY) {
+    flags |= private_handle_t::PRIV_FLAGS_EXTERNAL_ONLY;
+  }
+
+  if (cons_usage & GRALLOC1_CONSUMER_USAGE_PRIVATE_INTERNAL_ONLY) {
+    flags |= private_handle_t::PRIV_FLAGS_INTERNAL_ONLY;
+  }
+
+  if (cons_usage & GRALLOC1_CONSUMER_USAGE_VIDEO_ENCODER) {
+    flags |= private_handle_t::PRIV_FLAGS_VIDEO_ENCODER;
+  }
+
+  if (prod_usage & GRALLOC1_PRODUCER_USAGE_CAMERA) {
+    flags |= private_handle_t::PRIV_FLAGS_CAMERA_WRITE;
+  }
+
+  if (prod_usage & GRALLOC1_CONSUMER_USAGE_CAMERA) {
+    flags |= private_handle_t::PRIV_FLAGS_CAMERA_READ;
+  }
+
+  if (cons_usage & GRALLOC1_CONSUMER_USAGE_HWCOMPOSER) {
+    flags |= private_handle_t::PRIV_FLAGS_HW_COMPOSER;
+  }
+
+  if (prod_usage & GRALLOC1_CONSUMER_USAGE_GPU_TEXTURE) {
+    flags |= private_handle_t::PRIV_FLAGS_HW_TEXTURE;
+  }
+
+  if (cons_usage & GRALLOC1_CONSUMER_USAGE_PRIVATE_SECURE_DISPLAY) {
+    flags |= private_handle_t::PRIV_FLAGS_SECURE_DISPLAY;
+  }
+
+  if (IsUBwcEnabled(format, prod_usage, cons_usage)) {
+    flags |= private_handle_t::PRIV_FLAGS_UBWC_ALIGNED;
+  }
+
+  if (prod_usage & (GRALLOC1_PRODUCER_USAGE_CPU_READ | GRALLOC1_PRODUCER_USAGE_CPU_WRITE)) {
+    flags |= private_handle_t::PRIV_FLAGS_CPU_RENDERED;
+  }
+
+  // TODO(user): is this correct???
+  if ((cons_usage &
+       (GRALLOC1_CONSUMER_USAGE_VIDEO_ENCODER | GRALLOC1_CONSUMER_USAGE_CLIENT_TARGET)) ||
+      (prod_usage & (GRALLOC1_PRODUCER_USAGE_CAMERA | GRALLOC1_PRODUCER_USAGE_GPU_RENDER_TARGET))) {
+    flags |= private_handle_t::PRIV_FLAGS_NON_CPU_WRITER;
+  }
+
+  if (cons_usage & GRALLOC1_CONSUMER_USAGE_HWCOMPOSER) {
+    flags |= private_handle_t::PRIV_FLAGS_DISP_CONSUMER;
+  }
+
+  if (!allocator_->UseUncached(prod_usage, cons_usage)) {
+    flags |= private_handle_t::PRIV_FLAGS_CACHED;
+  }
+
+  return flags;
+}
+
+int BufferManager::GetBufferType(int inputFormat) {
+  int buffer_type = BUFFER_TYPE_VIDEO;
+  if (IsUncompressedRGBFormat(inputFormat)) {
+    // RGB formats
+    buffer_type = BUFFER_TYPE_UI;
+  }
+
+  return buffer_type;
+}
+
+int BufferManager::AllocateBuffer(const BufferDescriptor &descriptor, buffer_handle_t *handle,
+                                  unsigned int bufferSize) {
+  if (!handle)
+    return -EINVAL;
+
+  int format = descriptor.GetFormat();
+  gralloc1_producer_usage_t prod_usage = descriptor.GetProducerUsage();
+  gralloc1_consumer_usage_t cons_usage = descriptor.GetConsumerUsage();
+  uint32_t layer_count = descriptor.GetLayerCount();
+
+  // Get implementation defined format
+  int gralloc_format = allocator_->GetImplDefinedFormat(prod_usage, cons_usage, format);
+
+  unsigned int size;
+  unsigned int alignedw, alignedh;
+  int buffer_type = GetBufferType(gralloc_format);
+  BufferInfo info = GetBufferInfo(descriptor);
+  GetBufferSizeAndDimensions(info, &size, &alignedw, &alignedh);
+  size = (bufferSize >= size) ? bufferSize : size;
+
+  int err = 0;
+  int flags = 0;
+  auto page_size = UINT(getpagesize());
+  AllocData data;
+  data.align = GetDataAlignment(format, prod_usage, cons_usage);
+  size = ALIGN(size, data.align) * layer_count;
+  data.size = size;
+  data.handle = (uintptr_t) handle;
+  data.uncached = allocator_->UseUncached(prod_usage, cons_usage);
+
+  // Allocate buffer memory
+  err = allocator_->AllocateMem(&data, prod_usage, cons_usage);
+  if (err) {
+    ALOGE("gralloc failed to allocate err=%s", strerror(-err));
+    return err;
+  }
+
+  // Allocate memory for MetaData
+  AllocData e_data;
+  e_data.size = ALIGN(UINT(sizeof(MetaData_t)), page_size);
+  e_data.handle = data.handle;
+  e_data.align = page_size;
+
+  err =
+      allocator_->AllocateMem(&e_data, GRALLOC1_PRODUCER_USAGE_NONE, GRALLOC1_CONSUMER_USAGE_NONE);
+  if (err) {
+    ALOGE("gralloc failed to allocate metadata error=%s", strerror(-err));
+    return err;
+  }
+
+  flags = GetHandleFlags(format, prod_usage, cons_usage);
+  flags |= data.alloc_type;
+
+  // Create handle
+  private_handle_t *hnd = new private_handle_t(data.fd,
+                                               e_data.fd,
+                                               flags,
+                                               INT(alignedw),
+                                               INT(alignedh),
+                                               descriptor.GetWidth(),
+                                               descriptor.GetHeight(),
+                                               format,
+                                               buffer_type,
+                                               data.size,
+                                               prod_usage,
+                                               cons_usage);
+
+  hnd->id = ++next_id_;
+  hnd->base = 0;
+  hnd->base_metadata = 0;
+  hnd->layer_count = layer_count;
+
+  ColorSpace_t colorSpace = ITU_R_601;
+  setMetaData(hnd, UPDATE_COLOR_SPACE, reinterpret_cast<void *>(&colorSpace));
+  *handle = hnd;
+  RegisterHandleLocked(hnd, data.ion_handle, e_data.ion_handle);
+  ALOGD_IF(DEBUG, "Allocated buffer handle: %p id: %" PRIu64, hnd, hnd->id);
+  if (DEBUG) {
+    private_handle_t::Dump(hnd);
+  }
+  return err;
+}
+
+gralloc1_error_t BufferManager::Perform(int operation, va_list args) {
+  switch (operation) {
+    case GRALLOC_MODULE_PERFORM_CREATE_HANDLE_FROM_BUFFER: {
+      int fd = va_arg(args, int);
+      unsigned int size = va_arg(args, unsigned int);
+      unsigned int offset = va_arg(args, unsigned int);
+      void *base = va_arg(args, void *);
+      int width = va_arg(args, int);
+      int height = va_arg(args, int);
+      int format = va_arg(args, int);
+
+      native_handle_t **handle = va_arg(args, native_handle_t **);
+      if (!handle) {
+        return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+
+      private_handle_t *hnd = reinterpret_cast<private_handle_t *>(
+          native_handle_create(private_handle_t::kNumFds, private_handle_t::NumInts()));
+      if (hnd) {
+        unsigned int alignedw = 0, alignedh = 0;
+        hnd->magic = private_handle_t::kMagic;
+        hnd->fd = fd;
+        hnd->flags = private_handle_t::PRIV_FLAGS_USES_ION;
+        hnd->size = size;
+        hnd->offset = offset;
+        hnd->base = uint64_t(base);
+        hnd->gpuaddr = 0;
+        BufferInfo info(width, height, format);
+        GetAlignedWidthAndHeight(info, &alignedw, &alignedh);
+        hnd->unaligned_width = width;
+        hnd->unaligned_height = height;
+        hnd->width = INT(alignedw);
+        hnd->height = INT(alignedh);
+        hnd->format = format;
+        *handle = reinterpret_cast<native_handle_t *>(hnd);
+      }
+    } break;
+
+    case GRALLOC_MODULE_PERFORM_GET_STRIDE: {
+      int width = va_arg(args, int);
+      int format = va_arg(args, int);
+      int *stride = va_arg(args, int *);
+      unsigned int alignedw = 0, alignedh = 0;
+
+      if (!stride) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      BufferInfo info(width, width, format);
+      GetAlignedWidthAndHeight(info, &alignedw, &alignedh);
+      *stride = INT(alignedw);
+    } break;
+
+    case GRALLOC_MODULE_PERFORM_GET_CUSTOM_STRIDE_FROM_HANDLE: {
+      private_handle_t *hnd = va_arg(args, private_handle_t *);
+      int *stride = va_arg(args, int *);
+      if (private_handle_t::validate(hnd) != 0) {
+        return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+
+      if (!stride) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      BufferDim_t buffer_dim;
+      if (getMetaData(hnd, GET_BUFFER_GEOMETRY, &buffer_dim) == 0) {
+        *stride = buffer_dim.sliceWidth;
+      } else {
+        *stride = hnd->width;
+      }
+    } break;
+
+    // TODO(user) : this alone should be sufficient, ask gfx to get rid of above
+    case GRALLOC_MODULE_PERFORM_GET_CUSTOM_STRIDE_AND_HEIGHT_FROM_HANDLE: {
+      private_handle_t *hnd = va_arg(args, private_handle_t *);
+      int *stride = va_arg(args, int *);
+      int *height = va_arg(args, int *);
+      if (private_handle_t::validate(hnd) != 0) {
+        return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+
+      if (!stride || !height) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      BufferDim_t buffer_dim;
+      if (getMetaData(hnd, GET_BUFFER_GEOMETRY, &buffer_dim) == 0) {
+        *stride = buffer_dim.sliceWidth;
+        *height = buffer_dim.sliceHeight;
+      } else {
+        *stride = hnd->width;
+        *height = hnd->height;
+      }
+    } break;
+
+    case GRALLOC_MODULE_PERFORM_GET_ATTRIBUTES: {
+      // TODO(user): Usage is split now. take care of it from Gfx client.
+      // see if we can directly expect descriptor from gfx client.
+      int width = va_arg(args, int);
+      int height = va_arg(args, int);
+      int format = va_arg(args, int);
+      uint64_t producer_usage = va_arg(args, uint64_t);
+      uint64_t consumer_usage = va_arg(args, uint64_t);
+      gralloc1_producer_usage_t prod_usage = static_cast<gralloc1_producer_usage_t>(producer_usage);
+      gralloc1_consumer_usage_t cons_usage = static_cast<gralloc1_consumer_usage_t>(consumer_usage);
+
+      int *aligned_width = va_arg(args, int *);
+      int *aligned_height = va_arg(args, int *);
+      int *tile_enabled = va_arg(args, int *);
+      if (!aligned_width || !aligned_height || !tile_enabled) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      unsigned int alignedw, alignedh;
+      BufferInfo info(width, height, format, prod_usage, cons_usage);
+      *tile_enabled = IsUBwcEnabled(format, prod_usage, cons_usage);
+      GetAlignedWidthAndHeight(info, &alignedw, &alignedh);
+      *aligned_width = INT(alignedw);
+      *aligned_height = INT(alignedh);
+    } break;
+
+    case GRALLOC_MODULE_PERFORM_GET_COLOR_SPACE_FROM_HANDLE: {
+      private_handle_t *hnd = va_arg(args, private_handle_t *);
+      int *color_space = va_arg(args, int *);
+
+      if (private_handle_t::validate(hnd) != 0) {
+        return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+
+      if (!color_space) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      *color_space = 0;
+      ColorMetaData color_metadata;
+      if (getMetaData(hnd, GET_COLOR_METADATA, &color_metadata) == 0) {
+        switch (color_metadata.colorPrimaries) {
+          case ColorPrimaries_BT709_5:
+            *color_space = HAL_CSC_ITU_R_709;
+            break;
+          case ColorPrimaries_BT601_6_525:
+          case ColorPrimaries_BT601_6_625:
+            *color_space = ((color_metadata.range) ? HAL_CSC_ITU_R_601_FR : HAL_CSC_ITU_R_601);
+            break;
+          case ColorPrimaries_BT2020:
+            *color_space = (color_metadata.range) ? HAL_CSC_ITU_R_2020_FR : HAL_CSC_ITU_R_2020;
+            break;
+          default:
+            ALOGE("Unknown Color Space = %d", color_metadata.colorPrimaries);
+            break;
+        }
+        break;
+      } else if (getMetaData(hnd, GET_COLOR_SPACE, color_space) != 0) {
+          *color_space = 0;
+      }
+    } break;
+    case GRALLOC_MODULE_PERFORM_GET_YUV_PLANE_INFO: {
+      private_handle_t *hnd = va_arg(args, private_handle_t *);
+      android_ycbcr *ycbcr = va_arg(args, struct android_ycbcr *);
+      if (private_handle_t::validate(hnd) != 0) {
+        return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+
+      if (!ycbcr) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      if (GetYUVPlaneInfo(hnd, ycbcr)) {
+        return GRALLOC1_ERROR_UNDEFINED;
+      }
+    } break;
+
+    case GRALLOC_MODULE_PERFORM_GET_MAP_SECURE_BUFFER_INFO: {
+      private_handle_t *hnd = va_arg(args, private_handle_t *);
+      int *map_secure_buffer = va_arg(args, int *);
+
+      if (private_handle_t::validate(hnd) != 0) {
+        return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+
+      if (!map_secure_buffer) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      if (getMetaData(hnd, GET_MAP_SECURE_BUFFER, map_secure_buffer) == 0) {
+        *map_secure_buffer = 0;
+      }
+    } break;
+
+    case GRALLOC_MODULE_PERFORM_GET_UBWC_FLAG: {
+      private_handle_t *hnd = va_arg(args, private_handle_t *);
+      int *flag = va_arg(args, int *);
+
+      if (private_handle_t::validate(hnd) != 0) {
+        return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+
+      if (!flag) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      *flag = hnd->flags &private_handle_t::PRIV_FLAGS_UBWC_ALIGNED;
+      int linear_format = 0;
+      if (getMetaData(hnd, GET_LINEAR_FORMAT, &linear_format) == 0) {
+        if (linear_format) {
+         *flag = 0;
+        }
+      }
+    } break;
+
+    case GRALLOC_MODULE_PERFORM_GET_RGB_DATA_ADDRESS: {
+      private_handle_t *hnd = va_arg(args, private_handle_t *);
+      void **rgb_data = va_arg(args, void **);
+
+      if (private_handle_t::validate(hnd) != 0) {
+        return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+
+      if (!rgb_data) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      if (GetRgbDataAddress(hnd, rgb_data)) {
+        return GRALLOC1_ERROR_UNDEFINED;
+      }
+    } break;
+
+    case GRALLOC1_MODULE_PERFORM_GET_BUFFER_SIZE_AND_DIMENSIONS: {
+      int width = va_arg(args, int);
+      int height = va_arg(args, int);
+      int format = va_arg(args, int);
+      uint64_t p_usage = va_arg(args, uint64_t);
+      uint64_t c_usage = va_arg(args, uint64_t);
+      gralloc1_producer_usage_t producer_usage = static_cast<gralloc1_producer_usage_t>(p_usage);
+      gralloc1_consumer_usage_t consumer_usage = static_cast<gralloc1_consumer_usage_t>(c_usage);
+      uint32_t *aligned_width = va_arg(args, uint32_t *);
+      uint32_t *aligned_height = va_arg(args, uint32_t *);
+      uint32_t *size = va_arg(args, uint32_t *);
+
+      if (!aligned_width || !aligned_height || !size) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      auto info = BufferInfo(width, height, format, producer_usage, consumer_usage);
+      GetBufferSizeAndDimensions(info, size, aligned_width, aligned_height);
+      // Align size
+      auto align = GetDataAlignment(format, producer_usage, consumer_usage);
+      *size = ALIGN(*size, align);
+    } break;
+
+    case GRALLOC1_MODULE_PERFORM_ALLOCATE_BUFFER: {
+      std::lock_guard<std::mutex> lock(buffer_lock_);
+      int width = va_arg(args, int);
+      int height = va_arg(args, int);
+      int format = va_arg(args, int);
+      uint64_t p_usage = va_arg(args, uint64_t);
+      uint64_t c_usage = va_arg(args, uint64_t);
+      buffer_handle_t *hnd = va_arg(args, buffer_handle_t*);
+      gralloc1_producer_usage_t producer_usage = static_cast<gralloc1_producer_usage_t>(p_usage);
+      gralloc1_consumer_usage_t consumer_usage = static_cast<gralloc1_consumer_usage_t>(c_usage);
+      BufferDescriptor descriptor(width, height, format, producer_usage, consumer_usage);
+      unsigned int size;
+      unsigned int alignedw, alignedh;
+      GetBufferSizeAndDimensions(GetBufferInfo(descriptor), &size, &alignedw, &alignedh);
+      AllocateBuffer(descriptor, hnd, size);
+    } break;
+
+    case GRALLOC1_MODULE_PERFORM_GET_INTERLACE_FLAG: {
+      private_handle_t *hnd = va_arg(args, private_handle_t *);
+      int *flag = va_arg(args, int *);
+
+      if (private_handle_t::validate(hnd) != 0) {
+        return GRALLOC1_ERROR_BAD_HANDLE;
+      }
+
+      if (!flag) {
+        return GRALLOC1_ERROR_BAD_VALUE;
+      }
+
+      if (getMetaData(hnd, GET_PP_PARAM_INTERLACED, flag) != 0) {
+        *flag = 0;
+      }
+    } break;
+
+    default:
+      break;
+  }
+  return GRALLOC1_ERROR_NONE;
+}
+
+static bool IsYuvFormat(const private_handle_t *hnd) {
+  switch (hnd->format) {
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP:
+    case HAL_PIXEL_FORMAT_YCbCr_422_SP:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:   // Same as YCbCr_420_SP_VENUS
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC:
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+    case HAL_PIXEL_FORMAT_YCrCb_422_SP:
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP_ADRENO:
+    case HAL_PIXEL_FORMAT_NV21_ZSL:
+    case HAL_PIXEL_FORMAT_RAW16:
+    case HAL_PIXEL_FORMAT_Y16:
+    case HAL_PIXEL_FORMAT_RAW12:
+    case HAL_PIXEL_FORMAT_RAW10:
+    case HAL_PIXEL_FORMAT_YV12:
+    case HAL_PIXEL_FORMAT_Y8:
+      return true;
+    default:
+      return false;
+  }
+}
+
+gralloc1_error_t BufferManager::GetNumFlexPlanes(const private_handle_t *hnd,
+                                                 uint32_t *out_num_planes) {
+  if (!IsYuvFormat(hnd)) {
+    return GRALLOC1_ERROR_UNSUPPORTED;
+  } else {
+    *out_num_planes = 3;
+  }
+  return GRALLOC1_ERROR_NONE;
+}
+
+gralloc1_error_t BufferManager::GetFlexLayout(const private_handle_t *hnd,
+                                              struct android_flex_layout *layout) {
+  if (!IsYuvFormat(hnd)) {
+    return GRALLOC1_ERROR_UNSUPPORTED;
+  }
+
+  android_ycbcr ycbcr;
+  int err = GetYUVPlaneInfo(hnd, &ycbcr);
+
+  if (err != 0) {
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+
+  layout->format = FLEX_FORMAT_YCbCr;
+  layout->num_planes = 3;
+
+  for (uint32_t i = 0; i < layout->num_planes; i++) {
+    layout->planes[i].bits_per_component = 8;
+    layout->planes[i].bits_used = 8;
+    layout->planes[i].h_increment = 1;
+    layout->planes[i].v_increment = 1;
+    layout->planes[i].h_subsampling = 2;
+    layout->planes[i].v_subsampling = 2;
+  }
+
+  layout->planes[0].top_left = static_cast<uint8_t *>(ycbcr.y);
+  layout->planes[0].component = FLEX_COMPONENT_Y;
+  layout->planes[0].v_increment = static_cast<int32_t>(ycbcr.ystride);
+
+  layout->planes[1].top_left = static_cast<uint8_t *>(ycbcr.cb);
+  layout->planes[1].component = FLEX_COMPONENT_Cb;
+  layout->planes[1].h_increment = static_cast<int32_t>(ycbcr.chroma_step);
+  layout->planes[1].v_increment = static_cast<int32_t>(ycbcr.cstride);
+
+  layout->planes[2].top_left = static_cast<uint8_t *>(ycbcr.cr);
+  layout->planes[2].component = FLEX_COMPONENT_Cr;
+  layout->planes[2].h_increment = static_cast<int32_t>(ycbcr.chroma_step);
+  layout->planes[2].v_increment = static_cast<int32_t>(ycbcr.cstride);
+  return GRALLOC1_ERROR_NONE;
+}
+
+gralloc1_error_t BufferManager::Dump(std::ostringstream *os) {
+  for (auto it : handles_map_) {
+    auto buf = it.second;
+    auto hnd = buf->handle;
+    *os << "handle id: " << std::setw(4) << hnd->id;
+    *os << " fd: "       << std::setw(3) << hnd->fd;
+    *os << " fd_meta: "  << std::setw(3) << hnd->fd_metadata;
+    *os << " wxh: "      << std::setw(4) << hnd->width <<" x " << std::setw(4) <<  hnd->height;
+    *os << " uwxuh: "    << std::setw(4) << hnd->unaligned_width << " x ";
+    *os << std::setw(4)  <<  hnd->unaligned_height;
+    *os << " size: "     << std::setw(9) << hnd->size;
+    *os << std::hex << std::setfill('0');
+    *os << " priv_flags: " << "0x" << std::setw(8) << hnd->flags;
+    *os << " prod_usage: " << "0x" << std::setw(8) << hnd->producer_usage;
+    *os << " cons_usage: " << "0x" << std::setw(8) << hnd->consumer_usage;
+    // TODO(user): get format string from qdutils
+    *os << " format: "     << "0x" << std::setw(8) << hnd->format;
+    *os << std::dec  << std::setfill(' ') << std::endl;
+  }
+  return GRALLOC1_ERROR_NONE;
+}
+}  //  namespace gralloc1

--- a/gralloc1/gr_buf_mgr.h
+++ b/gralloc1/gr_buf_mgr.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2011-2017, The Linux Foundation. All rights reserved.
+ * Not a Contribution
+ *
+ * Copyright (C) 2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __GR_BUF_MGR_H__
+#define __GR_BUF_MGR_H__
+
+#include <pthread.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <mutex>
+
+#include "gralloc_priv.h"
+#include "gr_allocator.h"
+#include "gr_buf_descriptor.h"
+
+namespace gralloc1 {
+
+class BufferManager {
+ public:
+  ~BufferManager();
+  gralloc1_error_t CreateBufferDescriptor(gralloc1_buffer_descriptor_t *descriptor_id);
+  gralloc1_error_t DestroyBufferDescriptor(gralloc1_buffer_descriptor_t descriptor_id);
+  gralloc1_error_t AllocateBuffers(uint32_t num_descriptors,
+                                   const gralloc1_buffer_descriptor_t *descriptor_ids,
+                                   buffer_handle_t *out_buffers);
+  gralloc1_error_t RetainBuffer(private_handle_t const *hnd);
+  gralloc1_error_t ReleaseBuffer(private_handle_t const *hnd);
+  gralloc1_error_t LockBuffer(const private_handle_t *hnd, gralloc1_producer_usage_t prod_usage,
+                              gralloc1_consumer_usage_t cons_usage);
+  gralloc1_error_t UnlockBuffer(const private_handle_t *hnd);
+  gralloc1_error_t Perform(int operation, va_list args);
+  gralloc1_error_t GetFlexLayout(const private_handle_t *hnd, struct android_flex_layout *layout);
+  gralloc1_error_t GetNumFlexPlanes(const private_handle_t *hnd, uint32_t *out_num_planes);
+  gralloc1_error_t Dump(std::ostringstream *os);
+
+  template <typename... Args>
+  gralloc1_error_t CallBufferDescriptorFunction(gralloc1_buffer_descriptor_t descriptor_id,
+                                                void (BufferDescriptor::*member)(Args...),
+                                                Args... args) {
+    std::lock_guard<std::mutex> lock(descriptor_lock_);
+    const auto map_descriptor = descriptors_map_.find(descriptor_id);
+    if (map_descriptor == descriptors_map_.end()) {
+      return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+    }
+    const auto descriptor = map_descriptor->second;
+    (descriptor.get()->*member)(std::forward<Args>(args)...);
+    return GRALLOC1_ERROR_NONE;
+  }
+
+  static BufferManager* GetInstance() {
+    static BufferManager *instance = new BufferManager();
+    return instance;
+  }
+
+ private:
+  BufferManager();
+  gralloc1_error_t MapBuffer(private_handle_t const *hnd);
+  int GetBufferType(int format);
+  int AllocateBuffer(const BufferDescriptor &descriptor, buffer_handle_t *handle,
+                     unsigned int bufferSize = 0);
+  uint32_t GetDataAlignment(int format, gralloc1_producer_usage_t prod_usage,
+                       gralloc1_consumer_usage_t cons_usage);
+  int GetHandleFlags(int format, gralloc1_producer_usage_t prod_usage,
+                     gralloc1_consumer_usage_t cons_usage);
+  void CreateSharedHandle(buffer_handle_t inbuffer, const BufferDescriptor &descriptor,
+                          buffer_handle_t *out_buffer);
+
+  // Imports the ion fds into the current process. Returns an error for invalid handles
+  gralloc1_error_t ImportHandleLocked(private_handle_t *hnd);
+
+  // Creates a Buffer from the valid private handle and adds it to the map
+  void RegisterHandleLocked(const private_handle_t *hnd, int ion_handle, int ion_handle_meta);
+
+  // Wrapper structure over private handle
+  // Values associated with the private handle
+  // that do not need to go over IPC can be placed here
+  // This structure is also not expected to be ABI stable
+  // unlike private_handle_t
+  struct Buffer {
+    const private_handle_t *handle = nullptr;
+    int ref_count = 1;
+    // Hold the main and metadata ion handles
+    // Freed from the allocator process
+    // and unused in the mapping process
+    int ion_handle_main = -1;
+    int ion_handle_meta = -1;
+
+    Buffer() = delete;
+    explicit Buffer(const private_handle_t* h, int ih_main = -1, int ih_meta = -1):
+        handle(h),
+        ion_handle_main(ih_main),
+        ion_handle_meta(ih_meta) {
+    }
+    void IncRef() { ++ref_count; }
+    bool DecRef() { return --ref_count == 0; }
+  };
+
+  gralloc1_error_t FreeBuffer(std::shared_ptr<Buffer> buf);
+
+  // Get the wrapper Buffer object from the handle, returns nullptr if handle is not found
+  std::shared_ptr<Buffer> GetBufferFromHandleLocked(const private_handle_t *hnd);
+
+  bool map_fb_mem_ = false;
+  Allocator *allocator_ = NULL;
+  std::mutex buffer_lock_;
+  std::mutex descriptor_lock_;
+  // TODO(user): The private_handle_t is used as a key because the unique ID generated
+  // from next_id_ is not unique across processes. The correct way to resolve this would
+  // be to use the allocator over hwbinder
+  std::unordered_map<const private_handle_t*, std::shared_ptr<Buffer>> handles_map_ = {};
+  std::unordered_map<gralloc1_buffer_descriptor_t,
+                     std::shared_ptr<BufferDescriptor>> descriptors_map_ = {};
+  std::atomic<uint64_t> next_id_;
+};
+
+}  // namespace gralloc1
+
+#endif  // __GR_BUF_MGR_H__

--- a/gralloc1/gr_device_impl.cpp
+++ b/gralloc1/gr_device_impl.cpp
@@ -1,0 +1,530 @@
+/*
+ * Copyright (c) 2016-2017, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <log/log.h>
+#include <sync/sync.h>
+#include <algorithm>
+#include <sstream>
+#include <string>
+
+#include "gr_device_impl.h"
+#include "gr_buf_descriptor.h"
+#include "gralloc_priv.h"
+#include "qd_utils.h"
+#include "qdMetaData.h"
+#include "gr_utils.h"
+
+int gralloc_device_open(const struct hw_module_t *module, const char *name, hw_device_t **device);
+
+int gralloc_device_close(struct hw_device_t *device);
+
+static struct hw_module_methods_t gralloc_module_methods = {.open = gralloc_device_open};
+
+struct gralloc_module_t HAL_MODULE_INFO_SYM = {
+  .common = {
+    .tag = HARDWARE_MODULE_TAG,
+    .module_api_version = GRALLOC_MODULE_API_VERSION_1_0,
+    .hal_api_version    = HARDWARE_HAL_API_VERSION,
+    .id = GRALLOC_HARDWARE_MODULE_ID,
+    .name = "Graphics Memory Module",
+    .author = "Code Aurora Forum",
+    .methods = &gralloc_module_methods,
+    .dso = 0,
+    .reserved = {0},
+  },
+};
+
+int gralloc_device_open(const struct hw_module_t *module, const char *name, hw_device_t **device) {
+  int status = -EINVAL;
+  if (!strcmp(name, GRALLOC_HARDWARE_MODULE_ID)) {
+    gralloc1::GrallocImpl * /*gralloc1_device_t*/ dev = gralloc1::GrallocImpl::GetInstance(module);
+    *device = reinterpret_cast<hw_device_t *>(dev);
+    if (dev) {
+      status = 0;
+    } else {
+      ALOGE("Fatal error opening gralloc1 device");
+    }
+  }
+  return status;
+}
+
+namespace gralloc1 {
+
+GrallocImpl::GrallocImpl(const hw_module_t *module) {
+  common.tag = HARDWARE_DEVICE_TAG;
+  common.version = GRALLOC_MODULE_API_VERSION_1_0;
+  common.module = const_cast<hw_module_t *>(module);
+  common.close = CloseDevice;
+  getFunction = GetFunction;
+  getCapabilities = GetCapabilities;
+
+  initalized_ = Init();
+}
+
+bool GrallocImpl::Init() {
+  buf_mgr_ = BufferManager::GetInstance();
+  return buf_mgr_ != nullptr;
+}
+
+GrallocImpl::~GrallocImpl() {
+}
+
+int GrallocImpl::CloseDevice(hw_device_t *device __unused) {
+  // No-op since the gralloc device is a singleton
+  return 0;
+}
+
+void GrallocImpl::GetCapabilities(struct gralloc1_device *device, uint32_t *out_count,
+                                  int32_t  /*gralloc1_capability_t*/ *out_capabilities) {
+  if (device != nullptr) {
+    if (out_capabilities != nullptr && *out_count >= 3) {
+      out_capabilities[0] = GRALLOC1_CAPABILITY_TEST_ALLOCATE;
+      out_capabilities[1] = GRALLOC1_CAPABILITY_LAYERED_BUFFERS;
+      out_capabilities[2] = GRALLOC1_CAPABILITY_RELEASE_IMPLY_DELETE;
+    }
+    *out_count = 3;
+  }
+  return;
+}
+
+gralloc1_function_pointer_t GrallocImpl::GetFunction(gralloc1_device_t *device, int32_t function) {
+  if (!device) {
+    return NULL;
+  }
+
+  switch (function) {
+    case GRALLOC1_FUNCTION_DUMP:
+      return reinterpret_cast<gralloc1_function_pointer_t>(Dump);
+    case GRALLOC1_FUNCTION_CREATE_DESCRIPTOR:
+      return reinterpret_cast<gralloc1_function_pointer_t>(CreateBufferDescriptor);
+    case GRALLOC1_FUNCTION_DESTROY_DESCRIPTOR:
+      return reinterpret_cast<gralloc1_function_pointer_t>(DestroyBufferDescriptor);
+    case GRALLOC1_FUNCTION_SET_CONSUMER_USAGE:
+      return reinterpret_cast<gralloc1_function_pointer_t>(SetConsumerUsage);
+    case GRALLOC1_FUNCTION_SET_DIMENSIONS:
+      return reinterpret_cast<gralloc1_function_pointer_t>(SetBufferDimensions);
+    case GRALLOC1_FUNCTION_SET_FORMAT:
+      return reinterpret_cast<gralloc1_function_pointer_t>(SetColorFormat);
+    case GRALLOC1_FUNCTION_SET_LAYER_COUNT:
+      return reinterpret_cast<gralloc1_function_pointer_t>(SetLayerCount);
+    case GRALLOC1_FUNCTION_SET_PRODUCER_USAGE:
+      return reinterpret_cast<gralloc1_function_pointer_t>(SetProducerUsage);
+    case GRALLOC1_FUNCTION_GET_BACKING_STORE:
+      return reinterpret_cast<gralloc1_function_pointer_t>(GetBackingStore);
+    case GRALLOC1_FUNCTION_GET_CONSUMER_USAGE:
+      return reinterpret_cast<gralloc1_function_pointer_t>(GetConsumerUsage);
+    case GRALLOC1_FUNCTION_GET_DIMENSIONS:
+      return reinterpret_cast<gralloc1_function_pointer_t>(GetBufferDimensions);
+    case GRALLOC1_FUNCTION_GET_FORMAT:
+      return reinterpret_cast<gralloc1_function_pointer_t>(GetColorFormat);
+    case GRALLOC1_FUNCTION_GET_LAYER_COUNT:
+      return reinterpret_cast<gralloc1_function_pointer_t>(GetLayerCount);
+    case GRALLOC1_FUNCTION_GET_PRODUCER_USAGE:
+      return reinterpret_cast<gralloc1_function_pointer_t>(GetProducerUsage);
+    case GRALLOC1_FUNCTION_GET_STRIDE:
+      return reinterpret_cast<gralloc1_function_pointer_t>(GetBufferStride);
+    case GRALLOC1_FUNCTION_ALLOCATE:
+      return reinterpret_cast<gralloc1_function_pointer_t>(AllocateBuffers);
+    case GRALLOC1_FUNCTION_RETAIN:
+      return reinterpret_cast<gralloc1_function_pointer_t>(RetainBuffer);
+    case GRALLOC1_FUNCTION_RELEASE:
+      return reinterpret_cast<gralloc1_function_pointer_t>(ReleaseBuffer);
+    case GRALLOC1_FUNCTION_GET_NUM_FLEX_PLANES:
+      return reinterpret_cast<gralloc1_function_pointer_t>(GetNumFlexPlanes);
+    case GRALLOC1_FUNCTION_LOCK:
+      return reinterpret_cast<gralloc1_function_pointer_t>(LockBuffer);
+    case GRALLOC1_FUNCTION_LOCK_FLEX:
+      return reinterpret_cast<gralloc1_function_pointer_t>(LockFlex);
+    case GRALLOC1_FUNCTION_UNLOCK:
+      return reinterpret_cast<gralloc1_function_pointer_t>(UnlockBuffer);
+    case GRALLOC1_FUNCTION_PERFORM:
+      return reinterpret_cast<gralloc1_function_pointer_t>(Gralloc1Perform);
+    default:
+      ALOGE("%s:Gralloc Error. Client Requested for unsupported function", __FUNCTION__);
+      return NULL;
+  }
+
+  return NULL;
+}
+
+gralloc1_error_t GrallocImpl::Dump(gralloc1_device_t *device, uint32_t *out_size,
+                                   char *out_buffer) {
+  if (!device) {
+    ALOGE("Gralloc Error : device=%p", (void *)device);
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  }
+  const size_t max_dump_size = 8192;
+  if (out_buffer == nullptr) {
+    *out_size = max_dump_size;
+  } else {
+    std::ostringstream os;
+    os << "-------------------------------" << std::endl;
+    os << "QTI gralloc dump:" << std::endl;
+    os << "-------------------------------" << std::endl;
+    GrallocImpl const *dev = GRALLOC_IMPL(device);
+    dev->buf_mgr_->Dump(&os);
+    os << "-------------------------------" << std::endl;
+    auto copied = os.str().copy(out_buffer, std::min(os.str().size(), max_dump_size), 0);
+    *out_size = UINT(copied);
+  }
+
+  return GRALLOC1_ERROR_NONE;
+}
+
+gralloc1_error_t GrallocImpl::CheckDeviceAndHandle(gralloc1_device_t *device,
+                                                   buffer_handle_t buffer) {
+  const private_handle_t *hnd = PRIV_HANDLE_CONST(buffer);
+  if (!device || (private_handle_t::validate(hnd) != 0)) {
+    ALOGE("Gralloc Error : device= %p, buffer-handle=%p", (void *)device, (void *)buffer);
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+
+  return GRALLOC1_ERROR_NONE;
+}
+
+gralloc1_error_t GrallocImpl::CreateBufferDescriptor(gralloc1_device_t *device,
+                                                     gralloc1_buffer_descriptor_t *out_descriptor) {
+  if (!device) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  }
+  GrallocImpl const *dev = GRALLOC_IMPL(device);
+  return dev->buf_mgr_->CreateBufferDescriptor(out_descriptor);
+}
+
+gralloc1_error_t GrallocImpl::DestroyBufferDescriptor(gralloc1_device_t *device,
+                                                      gralloc1_buffer_descriptor_t descriptor) {
+  if (!device) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  }
+  GrallocImpl const *dev = GRALLOC_IMPL(device);
+  return dev->buf_mgr_->DestroyBufferDescriptor(descriptor);
+}
+
+gralloc1_error_t GrallocImpl::SetConsumerUsage(gralloc1_device_t *device,
+                                               gralloc1_buffer_descriptor_t descriptor,
+                                               gralloc1_consumer_usage_t usage) {
+  if (!device) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  } else {
+    GrallocImpl const *dev = GRALLOC_IMPL(device);
+    return dev->buf_mgr_->CallBufferDescriptorFunction(descriptor,
+                                                       &BufferDescriptor::SetConsumerUsage, usage);
+  }
+}
+
+gralloc1_error_t GrallocImpl::SetBufferDimensions(gralloc1_device_t *device,
+                                                  gralloc1_buffer_descriptor_t descriptor,
+                                                  uint32_t width, uint32_t height) {
+  if (!device) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  } else {
+    GrallocImpl const *dev = GRALLOC_IMPL(device);
+    return dev->buf_mgr_->CallBufferDescriptorFunction(descriptor,
+                                                       &BufferDescriptor::SetDimensions,
+                                                       INT(width), INT(height));
+  }
+}
+
+gralloc1_error_t GrallocImpl::SetColorFormat(gralloc1_device_t *device,
+                                             gralloc1_buffer_descriptor_t descriptor,
+                                             int32_t format) {
+  if (!device) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  } else {
+    GrallocImpl const *dev = GRALLOC_IMPL(device);
+    return dev->buf_mgr_->CallBufferDescriptorFunction(descriptor,
+                                                       &BufferDescriptor::SetColorFormat, format);
+  }
+}
+
+gralloc1_error_t GrallocImpl::SetLayerCount(gralloc1_device_t *device,
+                                            gralloc1_buffer_descriptor_t descriptor,
+                                            uint32_t layer_count) {
+  if (!device) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  } else {
+    GrallocImpl const *dev = GRALLOC_IMPL(device);
+    return dev->buf_mgr_->CallBufferDescriptorFunction(descriptor,
+                                                       &BufferDescriptor::SetLayerCount,
+                                                       layer_count);
+  }
+}
+
+gralloc1_error_t GrallocImpl::SetProducerUsage(gralloc1_device_t *device,
+                                               gralloc1_buffer_descriptor_t descriptor,
+                                               gralloc1_producer_usage_t usage) {
+  if (!device) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  } else {
+    GrallocImpl const *dev = GRALLOC_IMPL(device);
+    return dev->buf_mgr_->CallBufferDescriptorFunction(descriptor,
+                                                       &BufferDescriptor::SetProducerUsage, usage);
+  }
+}
+
+gralloc1_error_t GrallocImpl::GetBackingStore(gralloc1_device_t *device, buffer_handle_t buffer,
+                                              gralloc1_backing_store_t *out_backstore) {
+  if (!device || !buffer) {
+    return GRALLOC1_ERROR_BAD_HANDLE;
+  }
+
+  *out_backstore =
+      static_cast<gralloc1_backing_store_t>(PRIV_HANDLE_CONST(buffer)->GetBackingstore());
+
+  return GRALLOC1_ERROR_NONE;
+}
+
+gralloc1_error_t GrallocImpl::GetConsumerUsage(gralloc1_device_t *device, buffer_handle_t buffer,
+                                               gralloc1_consumer_usage_t *outUsage) {
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status == GRALLOC1_ERROR_NONE) {
+    *outUsage = PRIV_HANDLE_CONST(buffer)->GetConsumerUsage();
+  }
+
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::GetBufferDimensions(gralloc1_device_t *device, buffer_handle_t buffer,
+                                                  uint32_t *outWidth, uint32_t *outHeight) {
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status == GRALLOC1_ERROR_NONE) {
+    const private_handle_t *hnd = PRIV_HANDLE_CONST(buffer);
+    *outWidth = UINT(hnd->GetUnalignedWidth());
+    *outHeight = UINT(hnd->GetUnalignedHeight());
+  }
+
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::GetColorFormat(gralloc1_device_t *device, buffer_handle_t buffer,
+                                             int32_t *outFormat) {
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status == GRALLOC1_ERROR_NONE) {
+    *outFormat = PRIV_HANDLE_CONST(buffer)->GetColorFormat();
+  }
+
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::GetLayerCount(gralloc1_device_t *device, buffer_handle_t buffer,
+                                            uint32_t *outLayerCount) {
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status == GRALLOC1_ERROR_NONE) {
+    *outLayerCount = PRIV_HANDLE_CONST(buffer)->GetLayerCount();
+  }
+
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::GetProducerUsage(gralloc1_device_t *device, buffer_handle_t buffer,
+                                               gralloc1_producer_usage_t *outUsage) {
+  if (!outUsage) {
+    return GRALLOC1_ERROR_BAD_VALUE;
+  }
+
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status == GRALLOC1_ERROR_NONE) {
+    const private_handle_t *hnd = PRIV_HANDLE_CONST(buffer);
+    *outUsage = hnd->GetProducerUsage();
+  }
+
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::GetBufferStride(gralloc1_device_t *device, buffer_handle_t buffer,
+                                              uint32_t *outStride) {
+  if (!outStride) {
+    return GRALLOC1_ERROR_BAD_VALUE;
+  }
+
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status == GRALLOC1_ERROR_NONE) {
+    *outStride = UINT(PRIV_HANDLE_CONST(buffer)->GetStride());
+  }
+
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::AllocateBuffers(gralloc1_device_t *device, uint32_t num_descriptors,
+                                              const gralloc1_buffer_descriptor_t *descriptors,
+                                              buffer_handle_t *out_buffers) {
+  if (!num_descriptors || !descriptors) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  }
+
+  if (!device) {
+    return GRALLOC1_ERROR_BAD_VALUE;
+  }
+
+  GrallocImpl const *dev = GRALLOC_IMPL(device);
+  gralloc1_error_t status = dev->buf_mgr_->AllocateBuffers(num_descriptors, descriptors,
+                                                           out_buffers);
+
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::RetainBuffer(gralloc1_device_t *device, buffer_handle_t buffer) {
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status == GRALLOC1_ERROR_NONE) {
+    const private_handle_t *hnd = PRIV_HANDLE_CONST(buffer);
+    GrallocImpl const *dev = GRALLOC_IMPL(device);
+    status = dev->buf_mgr_->RetainBuffer(hnd);
+  }
+
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::ReleaseBuffer(gralloc1_device_t *device, buffer_handle_t buffer) {
+  if (!device || !buffer) {
+    return GRALLOC1_ERROR_BAD_DESCRIPTOR;
+  }
+
+  const private_handle_t *hnd = PRIV_HANDLE_CONST(buffer);
+  GrallocImpl const *dev = GRALLOC_IMPL(device);
+  return dev->buf_mgr_->ReleaseBuffer(hnd);
+}
+
+gralloc1_error_t GrallocImpl::GetNumFlexPlanes(gralloc1_device_t *device, buffer_handle_t buffer,
+                                               uint32_t *out_num_planes) {
+  if (!out_num_planes) {
+    return GRALLOC1_ERROR_BAD_VALUE;
+  }
+
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status == GRALLOC1_ERROR_NONE) {
+    GrallocImpl const *dev = GRALLOC_IMPL(device);
+    const private_handle_t *hnd = PRIV_HANDLE_CONST(buffer);
+    status = dev->buf_mgr_->GetNumFlexPlanes(hnd, out_num_planes);
+  }
+  return status;
+}
+
+static inline void CloseFdIfValid(int fd) {
+  if (fd > 0) {
+    close(fd);
+  }
+}
+
+gralloc1_error_t GrallocImpl::LockBuffer(gralloc1_device_t *device, buffer_handle_t buffer,
+                                         gralloc1_producer_usage_t prod_usage,
+                                         gralloc1_consumer_usage_t cons_usage,
+                                         const gralloc1_rect_t *region, void **out_data,
+                                         int32_t acquire_fence) {
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status != GRALLOC1_ERROR_NONE || !out_data ||
+      !region) {  // currently we ignore the region/rect client wants to lock
+    CloseFdIfValid(acquire_fence);
+    return status;
+  }
+
+  if (acquire_fence > 0) {
+    int error = sync_wait(acquire_fence, 1000);
+    CloseFdIfValid(acquire_fence);
+    if (error < 0) {
+      ALOGE("%s: sync_wait timedout! error = %s", __FUNCTION__, strerror(errno));
+      return GRALLOC1_ERROR_UNDEFINED;
+    }
+  }
+
+  const private_handle_t *hnd = PRIV_HANDLE_CONST(buffer);
+  GrallocImpl const *dev = GRALLOC_IMPL(device);
+
+  // Either producer usage or consumer usage must be *_USAGE_NONE
+  if ((prod_usage != GRALLOC1_PRODUCER_USAGE_NONE) &&
+      (cons_usage != GRALLOC1_CONSUMER_USAGE_NONE)) {
+    // Current gralloc1 clients do not satisfy this restriction.
+    // See b/33588773 for details
+    // return GRALLOC1_ERROR_BAD_VALUE;
+  }
+
+  // TODO(user): Need to check if buffer was allocated with the same flags
+  status = dev->buf_mgr_->LockBuffer(hnd, prod_usage, cons_usage);
+  *out_data = reinterpret_cast<void *>(hnd->base);
+
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::LockFlex(gralloc1_device_t *device, buffer_handle_t buffer,
+                                       gralloc1_producer_usage_t prod_usage,
+                                       gralloc1_consumer_usage_t cons_usage,
+                                       const gralloc1_rect_t *region,
+                                       struct android_flex_layout *out_flex_layout,
+                                       int32_t acquire_fence) {
+  if (!out_flex_layout) {
+    CloseFdIfValid(acquire_fence);
+    return GRALLOC1_ERROR_BAD_VALUE;
+  }
+
+  void *out_data {};
+  gralloc1_error_t status = GrallocImpl::LockBuffer(device, buffer, prod_usage, cons_usage, region,
+                                                    &out_data, acquire_fence);
+  if (status != GRALLOC1_ERROR_NONE) {
+    return status;
+  }
+
+  GrallocImpl const *dev = GRALLOC_IMPL(device);
+  const private_handle_t *hnd = PRIV_HANDLE_CONST(buffer);
+  dev->buf_mgr_->GetFlexLayout(hnd, out_flex_layout);
+  return status;
+}
+
+gralloc1_error_t GrallocImpl::UnlockBuffer(gralloc1_device_t *device, buffer_handle_t buffer,
+                                           int32_t *release_fence) {
+  gralloc1_error_t status = CheckDeviceAndHandle(device, buffer);
+  if (status != GRALLOC1_ERROR_NONE) {
+    return status;
+  }
+
+  if (!release_fence) {
+    return GRALLOC1_ERROR_BAD_VALUE;
+  }
+
+  const private_handle_t *hnd = PRIV_HANDLE_CONST(buffer);
+  GrallocImpl const *dev = GRALLOC_IMPL(device);
+
+  *release_fence = -1;
+
+  return dev->buf_mgr_->UnlockBuffer(hnd);
+}
+
+gralloc1_error_t GrallocImpl::Gralloc1Perform(gralloc1_device_t *device, int operation, ...) {
+  if (!device) {
+    return GRALLOC1_ERROR_BAD_VALUE;
+  }
+
+  va_list args;
+  va_start(args, operation);
+  GrallocImpl const *dev = GRALLOC_IMPL(device);
+  gralloc1_error_t err = dev->buf_mgr_->Perform(operation, args);
+  va_end(args);
+
+  return err;
+}
+
+}  // namespace gralloc1

--- a/gralloc1/gr_device_impl.h
+++ b/gralloc1/gr_device_impl.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2016-2017, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GR_DEVICE_IMPL_H__
+#define __GR_DEVICE_IMPL_H__
+
+#include <hardware/hardware.h>
+#include <hardware/gralloc1.h>
+#include "gr_buf_mgr.h"
+
+struct private_module_t {
+  hw_module_t base;
+};
+
+#define GRALLOC_IMPL(exp) reinterpret_cast<GrallocImpl const *>(exp)
+
+namespace gralloc1 {
+
+class GrallocImpl : public gralloc1_device_t {
+ public:
+  static int CloseDevice(hw_device_t *device);
+  static void GetCapabilities(struct gralloc1_device *device, uint32_t *out_count,
+                              int32_t * /*gralloc1_capability_t*/ out_capabilities);
+  static gralloc1_function_pointer_t GetFunction(
+      struct gralloc1_device *device, int32_t /*gralloc1_function_descriptor_t*/ descriptor);
+
+  static GrallocImpl* GetInstance(const struct hw_module_t *module) {
+    static GrallocImpl *instance = new GrallocImpl(module);
+    if (instance->IsInitialized()) {
+      return instance;
+    } else {
+      return nullptr;
+    }
+  }
+
+ private:
+  static inline gralloc1_error_t Dump(gralloc1_device_t *device, uint32_t *out_size,
+                                      char *out_buffer);
+  static inline gralloc1_error_t CheckDeviceAndHandle(gralloc1_device_t *device,
+                                                      buffer_handle_t buffer);
+  static gralloc1_error_t CreateBufferDescriptor(gralloc1_device_t *device,
+                                                 gralloc1_buffer_descriptor_t *out_descriptor);
+  static gralloc1_error_t DestroyBufferDescriptor(gralloc1_device_t *device,
+                                                  gralloc1_buffer_descriptor_t descriptor);
+  static gralloc1_error_t SetConsumerUsage(gralloc1_device_t *device,
+                                           gralloc1_buffer_descriptor_t descriptor,
+                                           gralloc1_consumer_usage_t usage);
+  static gralloc1_error_t SetBufferDimensions(gralloc1_device_t *device,
+                                              gralloc1_buffer_descriptor_t descriptor,
+                                              uint32_t width, uint32_t height);
+  static gralloc1_error_t SetColorFormat(gralloc1_device_t *device,
+                                         gralloc1_buffer_descriptor_t descriptor, int32_t format);
+  static gralloc1_error_t SetLayerCount(gralloc1_device_t *device,
+                                        gralloc1_buffer_descriptor_t descriptor,
+                                        uint32_t layer_count);
+  static gralloc1_error_t SetProducerUsage(gralloc1_device_t *device,
+                                           gralloc1_buffer_descriptor_t descriptor,
+                                           gralloc1_producer_usage_t usage);
+  static gralloc1_error_t GetBackingStore(gralloc1_device_t *device, buffer_handle_t buffer,
+                                          gralloc1_backing_store_t *out_store);
+  static gralloc1_error_t GetConsumerUsage(gralloc1_device_t *device, buffer_handle_t buffer,
+                                           gralloc1_consumer_usage_t *out_usage);
+  static gralloc1_error_t GetBufferDimensions(gralloc1_device_t *device, buffer_handle_t buffer,
+                                              uint32_t *out_width, uint32_t *out_height);
+  static gralloc1_error_t GetColorFormat(gralloc1_device_t *device, buffer_handle_t descriptor,
+                                         int32_t *outFormat);
+  static gralloc1_error_t GetLayerCount(gralloc1_device_t *device, buffer_handle_t buffer,
+                                        uint32_t *out_layer_count);
+  static gralloc1_error_t GetProducerUsage(gralloc1_device_t *device, buffer_handle_t buffer,
+                                           gralloc1_producer_usage_t *out_usage);
+  static gralloc1_error_t GetBufferStride(gralloc1_device_t *device, buffer_handle_t buffer,
+                                          uint32_t *out_stride);
+  static gralloc1_error_t AllocateBuffers(gralloc1_device_t *device, uint32_t num_dptors,
+                                          const gralloc1_buffer_descriptor_t *descriptors,
+                                          buffer_handle_t *out_buffers);
+  static gralloc1_error_t RetainBuffer(gralloc1_device_t *device, buffer_handle_t buffer);
+  static gralloc1_error_t ReleaseBuffer(gralloc1_device_t *device, buffer_handle_t buffer);
+  static gralloc1_error_t GetNumFlexPlanes(gralloc1_device_t *device, buffer_handle_t buffer,
+                                           uint32_t *out_num_planes);
+  static gralloc1_error_t LockBuffer(gralloc1_device_t *device, buffer_handle_t buffer,
+                                     gralloc1_producer_usage_t prod_usage,
+                                     gralloc1_consumer_usage_t cons_usage,
+                                     const gralloc1_rect_t *region, void **out_data,
+                                     int32_t acquire_fence);
+  static gralloc1_error_t LockFlex(gralloc1_device_t *device, buffer_handle_t buffer,
+                                   gralloc1_producer_usage_t prod_usage,
+                                   gralloc1_consumer_usage_t cons_usage,
+                                   const gralloc1_rect_t *region,
+                                   struct android_flex_layout *out_flex_layout,
+                                   int32_t acquire_fence);
+
+  static gralloc1_error_t UnlockBuffer(gralloc1_device_t *device, buffer_handle_t buffer,
+                                       int32_t *release_fence);
+  static gralloc1_error_t Gralloc1Perform(gralloc1_device_t *device, int operation, ...);
+
+  explicit GrallocImpl(const hw_module_t *module);
+  ~GrallocImpl();
+  bool Init();
+  bool IsInitialized() const { return initalized_; }
+
+  BufferManager *buf_mgr_ = NULL;
+  bool initalized_ = false;
+};
+
+}  // namespace gralloc1
+
+#endif  // __GR_DEVICE_IMPL_H__

--- a/gralloc1/gr_ion_alloc.cpp
+++ b/gralloc1/gr_ion_alloc.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2011-2017, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define DEBUG 0
+#define ATRACE_TAG (ATRACE_TAG_GRAPHICS | ATRACE_TAG_HAL)
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <log/log.h>
+#include <errno.h>
+#include <utils/Trace.h>
+
+#include "gralloc_priv.h"
+#include "gr_utils.h"
+#include "gr_ion_alloc.h"
+
+namespace gralloc1 {
+
+bool IonAlloc::Init() {
+  if (ion_dev_fd_ == FD_INIT) {
+    ion_dev_fd_ = open(kIonDevice, O_RDONLY);
+  }
+
+  if (ion_dev_fd_ < 0) {
+    ALOGE("%s: Failed to open ion device - %s", __FUNCTION__, strerror(errno));
+    ion_dev_fd_ = FD_INIT;
+    return false;
+  }
+
+  return true;
+}
+
+void IonAlloc::CloseIonDevice() {
+  if (ion_dev_fd_ > FD_INIT) {
+    close(ion_dev_fd_);
+  }
+
+  ion_dev_fd_ = FD_INIT;
+}
+
+int IonAlloc::AllocBuffer(AllocData *data) {
+  ATRACE_CALL();
+  int err = 0;
+  struct ion_handle_data handle_data;
+  struct ion_fd_data fd_data;
+  struct ion_allocation_data ion_alloc_data;
+
+  ion_alloc_data.len = data->size;
+  ion_alloc_data.align = data->align;
+  ion_alloc_data.heap_id_mask = data->heap_id;
+  ion_alloc_data.flags = data->flags;
+  ion_alloc_data.flags |= data->uncached ? 0 : ION_FLAG_CACHED;
+
+  if (ioctl(ion_dev_fd_, INT(ION_IOC_ALLOC), &ion_alloc_data)) {
+    err = -errno;
+    ALOGE("ION_IOC_ALLOC failed with error - %s", strerror(errno));
+    return err;
+  }
+
+  fd_data.handle = ion_alloc_data.handle;
+  handle_data.handle = ion_alloc_data.handle;
+  if (ioctl(ion_dev_fd_, INT(ION_IOC_MAP), &fd_data)) {
+    err = -errno;
+    ALOGE("%s: ION_IOC_MAP failed with error - %s", __FUNCTION__, strerror(errno));
+    ioctl(ion_dev_fd_, INT(ION_IOC_FREE), &handle_data);
+    return err;
+  }
+
+  data->fd = fd_data.fd;
+  data->ion_handle = handle_data.handle;
+  ALOGD_IF(DEBUG, "ion: Allocated buffer size:%zu fd:%d handle:0x%x",
+          ion_alloc_data.len, data->fd, data->ion_handle);
+
+  return 0;
+}
+
+int IonAlloc::FreeBuffer(void *base, unsigned int size, unsigned int offset, int fd,
+                         int ion_handle) {
+  ATRACE_CALL();
+  int err = 0;
+  ALOGD_IF(DEBUG, "ion: Freeing buffer base:%p size:%u fd:%d handle:0x%x", base, size, fd,
+           ion_handle);
+
+  if (base) {
+    err = UnmapBuffer(base, size, offset);
+  }
+
+  if (ion_handle > 0) {
+    struct ion_handle_data handle_data;
+    handle_data.handle = ion_handle;
+    ioctl(ion_dev_fd_, INT(ION_IOC_FREE), &handle_data);
+  }
+  close(fd);
+  return err;
+}
+
+int IonAlloc::MapBuffer(void **base, unsigned int size, unsigned int offset, int fd) {
+  ATRACE_CALL();
+  int err = 0;
+  void *addr = 0;
+
+  // It is a (quirky) requirement of ION to have opened the
+  // ion fd in the process that is doing the mapping
+  addr = mmap(0, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  *base = addr;
+  if (addr == MAP_FAILED) {
+    err = -errno;
+    ALOGE("ion: Failed to map memory in the client: %s", strerror(errno));
+  } else {
+    ALOGD_IF(DEBUG, "ion: Mapped buffer base:%p size:%u offset:%u fd:%d", addr, size, offset, fd);
+  }
+
+  return err;
+}
+
+int IonAlloc::ImportBuffer(int fd) {
+  struct ion_fd_data fd_data;
+  int err = 0;
+  fd_data.fd = fd;
+  if (ioctl(ion_dev_fd_, INT(ION_IOC_IMPORT), &fd_data)) {
+    err = -errno;
+    ALOGE("%s: ION_IOC_IMPORT failed with error - %s", __FUNCTION__, strerror(errno));
+    return err;
+  }
+  return fd_data.handle;
+}
+
+int IonAlloc::UnmapBuffer(void *base, unsigned int size, unsigned int /*offset*/) {
+  ATRACE_CALL();
+  ALOGD_IF(DEBUG, "ion: Unmapping buffer  base:%p size:%u", base, size);
+
+  int err = 0;
+  if (munmap(base, size)) {
+    err = -errno;
+    ALOGE("ion: Failed to unmap memory at %p : %s", base, strerror(errno));
+  }
+
+  return err;
+}
+
+int IonAlloc::CleanBuffer(void *base, unsigned int size, unsigned int offset, int handle, int op) {
+  ATRACE_CALL();
+  ATRACE_INT("operation id", op);
+  struct ion_flush_data flush_data;
+  int err = 0;
+
+  flush_data.handle = handle;
+  flush_data.vaddr = base;
+  // offset and length are unsigned int
+  flush_data.offset = offset;
+  flush_data.length = size;
+
+  struct ion_custom_data d;
+  switch (op) {
+    case CACHE_CLEAN:
+      d.cmd = ION_IOC_CLEAN_CACHES;
+      break;
+    case CACHE_INVALIDATE:
+      d.cmd = ION_IOC_INV_CACHES;
+      break;
+    case CACHE_CLEAN_AND_INVALIDATE:
+    default:
+      d.cmd = ION_IOC_CLEAN_INV_CACHES;
+  }
+
+  d.arg = (unsigned long)(&flush_data);  // NOLINT
+  if (ioctl(ion_dev_fd_, INT(ION_IOC_CUSTOM), &d)) {
+    err = -errno;
+    ALOGE("%s: ION_IOC_CLEAN_INV_CACHES failed with error - %s", __FUNCTION__, strerror(errno));
+    return err;
+  }
+
+  return 0;
+}
+
+}  // namespace gralloc1

--- a/gralloc1/gr_ion_alloc.h
+++ b/gralloc1/gr_ion_alloc.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2011-2017, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GR_ION_ALLOC_H__
+#define __GR_ION_ALLOC_H__
+
+#include <linux/msm_ion.h>
+
+#define FD_INIT -1
+
+namespace gralloc1 {
+
+enum {
+  CACHE_CLEAN = 0x1,
+  CACHE_INVALIDATE,
+  CACHE_CLEAN_AND_INVALIDATE,
+};
+
+struct AllocData {
+  void *base = NULL;
+  int fd = -1;
+  int ion_handle = -1;
+  unsigned int offset = 0;
+  unsigned int size = 0;
+  unsigned int align = 1;
+  uintptr_t handle = 0;
+  bool uncached = false;
+  unsigned int flags = 0x0;
+  unsigned int heap_id = 0x0;
+  unsigned int alloc_type = 0x0;
+};
+
+class IonAlloc {
+ public:
+  IonAlloc() { ion_dev_fd_ = FD_INIT; }
+
+  ~IonAlloc() { CloseIonDevice(); }
+
+  bool Init();
+  int AllocBuffer(AllocData *data);
+  int FreeBuffer(void *base, unsigned int size, unsigned int offset, int fd, int ion_handle);
+  int MapBuffer(void **base, unsigned int size, unsigned int offset, int fd);
+  int ImportBuffer(int fd);
+  int UnmapBuffer(void *base, unsigned int size, unsigned int offset);
+  int CleanBuffer(void *base, unsigned int size, unsigned int offset, int handle, int op);
+
+ private:
+  const char *kIonDevice = "/dev/ion";
+
+  int OpenIonDevice();
+  void CloseIonDevice();
+
+  int ion_dev_fd_;
+};
+
+}  // namespace gralloc1
+
+#endif  // __GR_ION_ALLOC_H__

--- a/gralloc1/gr_priv_handle.h
+++ b/gralloc1/gr_priv_handle.h
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2011-2018, The Linux Foundation. All rights reserved.
+ * Not a Contribution
+ *
+ * Copyright (C) 2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __GR_PRIV_HANDLE_H__
+#define __GR_PRIV_HANDLE_H__
+
+#include <errno.h>
+#include <log/log.h>
+#include <hardware/gralloc1.h>
+#include <hardware/gralloc.h>
+#ifdef __cplusplus
+#include <cinttypes>
+#endif
+
+#define GRALLOC1_FUNCTION_PERFORM 0x00001000
+
+#define DBG_HANDLE false
+
+typedef gralloc1_error_t (*GRALLOC1_PFN_PERFORM)(gralloc1_device_t *device, int operation, ...);
+
+#define PRIV_HANDLE_CONST(exp) static_cast<const private_handle_t *>(exp)
+
+#pragma pack(push, 4)
+
+#ifdef __cplusplus
+struct private_handle_t : public native_handle_t {
+#else
+struct private_handle_t {
+        native_handle_t nativeHandle;
+#endif
+  enum {
+    PRIV_FLAGS_FRAMEBUFFER = 0x00000001,
+    PRIV_FLAGS_USES_ION = 0x00000008,
+    PRIV_FLAGS_NEEDS_FLUSH = 0x00000020,
+    PRIV_FLAGS_INTERNAL_ONLY = 0x00000040,
+    PRIV_FLAGS_NON_CPU_WRITER = 0x00000080,
+    PRIV_FLAGS_CACHED = 0x00000200,
+    PRIV_FLAGS_SECURE_BUFFER = 0x00000400,
+    PRIV_FLAGS_EXTERNAL_ONLY = 0x00002000,
+    PRIV_FLAGS_PROTECTED_BUFFER = 0x00004000,
+    PRIV_FLAGS_VIDEO_ENCODER = 0x00010000,
+    PRIV_FLAGS_CAMERA_WRITE = 0x00020000,
+    PRIV_FLAGS_CAMERA_READ = 0x00040000,
+    PRIV_FLAGS_HW_COMPOSER = 0x00080000,
+    PRIV_FLAGS_HW_TEXTURE = 0x00100000,
+    PRIV_FLAGS_ITU_R_601 = 0x00200000,     // Unused from display
+    PRIV_FLAGS_ITU_R_601_FR = 0x00400000,  // Unused from display
+    PRIV_FLAGS_ITU_R_709 = 0x00800000,     // Unused from display
+    PRIV_FLAGS_SECURE_DISPLAY = 0x01000000,
+    PRIV_FLAGS_TILE_RENDERED = 0x02000000,
+    PRIV_FLAGS_CPU_RENDERED = 0x04000000,
+    PRIV_FLAGS_UBWC_ALIGNED = 0x08000000,
+    PRIV_FLAGS_DISP_CONSUMER = 0x10000000,
+    PRIV_FLAGS_CLIENT_ALLOCATED = 0x20000000,   // Ion buffer allocated outside of gralloc
+  };
+
+  // file-descriptors dup'd over IPC
+  int fd;
+  int fd_metadata;
+
+  // values sent over IPC
+  int magic;
+  int flags;
+  int width;        // holds width of the actual buffer allocated
+  int height;       // holds height of the  actual buffer allocated
+  int unaligned_width;   // holds width client asked to allocate
+  int unaligned_height;  // holds height client asked to allocate
+  int format;
+  int buffer_type;
+  unsigned int size;
+  unsigned int offset;
+  unsigned int offset_metadata;
+  uint64_t base                            __attribute__((aligned(8)));
+  uint64_t base_metadata                   __attribute__((aligned(8)));
+  uint64_t gpuaddr                         __attribute__((aligned(8)));
+  uint64_t id                              __attribute__((aligned(8)));
+  gralloc1_producer_usage_t producer_usage __attribute__((aligned(8)));
+  gralloc1_consumer_usage_t consumer_usage __attribute__((aligned(8)));
+  unsigned int layer_count;
+#ifdef __cplusplus
+  static const int kNumFds = 2;
+  static const int kMagic = 'gmsm';
+
+  static inline int NumInts() {
+    return ((sizeof(private_handle_t) - sizeof(native_handle_t)) / sizeof(int))
+        - kNumFds;
+  }
+
+  private_handle_t(int fd,
+                   int meta_fd,
+                   int flags,
+                   int width,
+                   int height,
+                   int uw,
+                   int uh,
+                   int format,
+                   int buf_type,
+                   unsigned int size,
+                   gralloc1_producer_usage_t prod_usage = GRALLOC1_PRODUCER_USAGE_NONE,
+                   gralloc1_consumer_usage_t cons_usage = GRALLOC1_CONSUMER_USAGE_NONE)
+      : fd(fd),
+        fd_metadata(meta_fd),
+        magic(kMagic),
+        flags(flags),
+        width(width),
+        height(height),
+        unaligned_width(uw),
+        unaligned_height(uh),
+        format(format),
+        buffer_type(buf_type),
+        size(size),
+        offset(0),
+        offset_metadata(0),
+        base(0),
+        base_metadata(0),
+        gpuaddr(0),
+        id(0),
+        producer_usage(prod_usage),
+        consumer_usage(cons_usage),
+        layer_count(1) {
+    version = static_cast<int>(sizeof(native_handle));
+    numInts = NumInts();
+    numFds = kNumFds;
+  }
+
+// Legacy constructor used by some clients
+  private_handle_t(int fd, unsigned int size, int usage, int buf_type, int format, int w, int h)
+  : private_handle_t(fd, -1, PRIV_FLAGS_CLIENT_ALLOCATED, w, h, 0, 0, format, buf_type, size,
+                     static_cast<gralloc1_producer_usage_t>(usage),
+                     static_cast<gralloc1_consumer_usage_t>(usage)) {
+  }
+
+  ~private_handle_t() {
+    magic = 0;
+    ALOGE_IF(DBG_HANDLE, "Deleting buffer handle %p", this);
+  }
+
+  static int validate(const native_handle *h) {
+    const private_handle_t *hnd = (const private_handle_t *)h;
+    if (!h || h->version != sizeof(native_handle) || h->numInts != NumInts() ||
+        h->numFds != kNumFds || hnd->magic != kMagic) {
+      ALOGE(
+          "Invalid gralloc handle (at %p): ver(%d/%zu) ints(%d/%d) fds(%d/%d) "
+          "magic(%c%c%c%c/%c%c%c%c)",
+          h, h ? h->version : -1, sizeof(native_handle), h ? h->numInts : -1, NumInts(),
+          h ? h->numFds : -1, kNumFds,
+          hnd ? (((hnd->magic >> 24) & 0xFF) ? ((hnd->magic >> 24) & 0xFF) : '-') : '?',
+          hnd ? (((hnd->magic >> 16) & 0xFF) ? ((hnd->magic >> 16) & 0xFF) : '-') : '?',
+          hnd ? (((hnd->magic >> 8) & 0xFF) ? ((hnd->magic >> 8) & 0xFF) : '-') : '?',
+          hnd ? (((hnd->magic >> 0) & 0xFF) ? ((hnd->magic >> 0) & 0xFF) : '-') : '?',
+          (kMagic >> 24) & 0xFF, (kMagic >> 16) & 0xFF, (kMagic >> 8) & 0xFF, (kMagic >> 0) & 0xFF);
+      return -EINVAL;
+    }
+
+    return 0;
+  }
+  static void Dump(const private_handle_t *hnd) {
+    ALOGD("handle id:%" PRIu64 " wxh:%dx%d uwxuh:%dx%d size: %d fd:%d fd_meta:%d flags:0x%x "
+          "prod_usage:0x%" PRIx64" cons_usage:0x%" PRIx64 " format:0x%x layer_count: %d",
+          hnd->id, hnd->width, hnd->height, hnd->unaligned_width, hnd->unaligned_height, hnd->size,
+          hnd->fd, hnd->fd_metadata, hnd->flags, hnd->producer_usage, hnd->consumer_usage,
+          hnd->format, hnd->layer_count);
+  }
+
+  int GetUnalignedWidth() const { return unaligned_width; }
+
+  int GetUnalignedHeight() const { return unaligned_height; }
+
+  int GetColorFormat() const { return format; }
+
+  unsigned int GetLayerCount() const { return layer_count; }
+
+  int GetStride() const {
+    // In handle we currently store aligned width after allocation.
+    return width;
+  }
+
+  gralloc1_consumer_usage_t GetConsumerUsage() const { return consumer_usage; }
+
+  gralloc1_producer_usage_t GetProducerUsage() const { return producer_usage; }
+
+  uint64_t GetBackingstore() const { return id; }
+#endif
+};
+#pragma pack(pop)
+
+#endif  // __GR_PRIV_HANDLE_H__

--- a/gralloc1/gr_utils.cpp
+++ b/gralloc1/gr_utils.cpp
@@ -1,0 +1,854 @@
+/*
+ * Copyright (c) 2011-2017, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <media/msm_media_info.h>
+#include <algorithm>
+
+#include "gr_utils.h"
+#include "gr_adreno_info.h"
+#include "qdMetaData.h"
+
+#define ASTC_BLOCK_SIZE 16
+
+#ifndef COLOR_FMT_P010_UBWC
+#define COLOR_FMT_P010_UBWC 9
+#endif
+
+namespace gralloc1 {
+
+bool IsUncompressedRGBFormat(int format) {
+  switch (format) {
+    case HAL_PIXEL_FORMAT_RGBA_8888:
+    case HAL_PIXEL_FORMAT_RGBX_8888:
+    case HAL_PIXEL_FORMAT_RGB_888:
+    case HAL_PIXEL_FORMAT_RGB_565:
+    case HAL_PIXEL_FORMAT_BGR_565:
+    case HAL_PIXEL_FORMAT_BGRA_8888:
+    case HAL_PIXEL_FORMAT_RGBA_5551:
+    case HAL_PIXEL_FORMAT_RGBA_4444:
+    case HAL_PIXEL_FORMAT_R_8:
+    case HAL_PIXEL_FORMAT_RG_88:
+    case HAL_PIXEL_FORMAT_BGRX_8888:
+    case HAL_PIXEL_FORMAT_RGBA_1010102:
+    case HAL_PIXEL_FORMAT_ARGB_2101010:
+    case HAL_PIXEL_FORMAT_RGBX_1010102:
+    case HAL_PIXEL_FORMAT_XRGB_2101010:
+    case HAL_PIXEL_FORMAT_BGRA_1010102:
+    case HAL_PIXEL_FORMAT_ABGR_2101010:
+    case HAL_PIXEL_FORMAT_BGRX_1010102:
+    case HAL_PIXEL_FORMAT_XBGR_2101010:
+    case HAL_PIXEL_FORMAT_RGBA_FP16:
+    case HAL_PIXEL_FORMAT_BGR_888:
+      return true;
+    default:
+      break;
+  }
+
+  return false;
+}
+
+bool IsCompressedRGBFormat(int format) {
+  switch (format) {
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_4x4_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_5x4_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_5x5_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_6x5_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_6x6_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_8x5_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_8x6_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_8x8_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_10x5_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_10x6_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_10x8_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_10x10_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_12x10_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_12x12_KHR:
+    case HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR:
+      return true;
+    default:
+      break;
+  }
+
+  return false;
+}
+
+uint32_t GetBppForUncompressedRGB(int format) {
+  uint32_t bpp = 0;
+  switch (format) {
+    case HAL_PIXEL_FORMAT_RGBA_FP16:
+      bpp = 8;
+      break;
+    case HAL_PIXEL_FORMAT_RGBA_8888:
+    case HAL_PIXEL_FORMAT_RGBX_8888:
+    case HAL_PIXEL_FORMAT_BGRA_8888:
+    case HAL_PIXEL_FORMAT_BGRX_8888:
+    case HAL_PIXEL_FORMAT_RGBA_1010102:
+    case HAL_PIXEL_FORMAT_ARGB_2101010:
+    case HAL_PIXEL_FORMAT_RGBX_1010102:
+    case HAL_PIXEL_FORMAT_XRGB_2101010:
+    case HAL_PIXEL_FORMAT_BGRA_1010102:
+    case HAL_PIXEL_FORMAT_ABGR_2101010:
+    case HAL_PIXEL_FORMAT_BGRX_1010102:
+    case HAL_PIXEL_FORMAT_XBGR_2101010:
+      bpp = 4;
+      break;
+    case HAL_PIXEL_FORMAT_RGB_888:
+    case HAL_PIXEL_FORMAT_BGR_888:
+      bpp = 3;
+      break;
+    case HAL_PIXEL_FORMAT_RGB_565:
+    case HAL_PIXEL_FORMAT_BGR_565:
+    case HAL_PIXEL_FORMAT_RGBA_5551:
+    case HAL_PIXEL_FORMAT_RGBA_4444:
+      bpp = 2;
+      break;
+    default:
+      ALOGE("Error : %s New format request = 0x%x", __FUNCTION__, format);
+      break;
+  }
+
+  return bpp;
+}
+
+bool CpuCanAccess(gralloc1_producer_usage_t prod_usage, gralloc1_consumer_usage_t cons_usage) {
+  return CpuCanRead(prod_usage, cons_usage) || CpuCanWrite(prod_usage);
+}
+
+bool CpuCanRead(gralloc1_producer_usage_t prod_usage, gralloc1_consumer_usage_t cons_usage) {
+  if (prod_usage & GRALLOC1_PRODUCER_USAGE_CPU_READ) {
+    return true;
+  }
+
+  if (cons_usage & GRALLOC1_CONSUMER_USAGE_CPU_READ) {
+    return true;
+  }
+
+  return false;
+}
+
+bool CpuCanWrite(gralloc1_producer_usage_t prod_usage) {
+  if (prod_usage & GRALLOC1_PRODUCER_USAGE_CPU_WRITE) {
+    // Application intends to use CPU for rendering
+    return true;
+  }
+
+  return false;
+}
+
+unsigned int GetSize(const BufferInfo &info, unsigned int alignedw,
+                     unsigned int alignedh) {
+  unsigned int size = 0;
+  int format = info.format;
+  int width = info.width;
+  int height = info.height;
+  gralloc1_producer_usage_t prod_usage = info.prod_usage;
+  gralloc1_consumer_usage_t cons_usage = info.cons_usage;
+
+  if (IsUBwcEnabled(format, prod_usage, cons_usage)) {
+    return GetUBwcSize(width, height, format, alignedw, alignedh);
+  }
+
+  if (IsUncompressedRGBFormat(format)) {
+    uint32_t bpp = GetBppForUncompressedRGB(format);
+    size = alignedw * alignedh * bpp;
+    return size;
+  }
+
+  if (IsCompressedRGBFormat(format)) {
+    size = alignedw * alignedh * ASTC_BLOCK_SIZE;
+    return size;
+  }
+
+  // Below switch should be for only YUV/custom formats
+  switch (format) {
+    case HAL_PIXEL_FORMAT_RAW16:
+    case HAL_PIXEL_FORMAT_Y16:
+      size = alignedw * alignedh * 2;
+      break;
+    case HAL_PIXEL_FORMAT_RAW10:
+    case HAL_PIXEL_FORMAT_RAW12:
+      size = ALIGN(alignedw * alignedh, SIZE_4K);
+      break;
+    case HAL_PIXEL_FORMAT_RAW8:
+    case HAL_PIXEL_FORMAT_Y8:
+      size = alignedw * alignedh * 1;
+      break;
+
+      // adreno formats
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP_ADRENO:  // NV21
+      size = ALIGN(alignedw * alignedh, SIZE_4K);
+      size += (unsigned int)ALIGN(2 * ALIGN(width / 2, 32) * ALIGN(height / 2, 32), SIZE_4K);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_TILED:  // NV12
+      // The chroma plane is subsampled,
+      // but the pitch in bytes is unchanged
+      // The GPU needs 4K alignment, but the video decoder needs 8K
+      size = ALIGN(alignedw * alignedh, SIZE_8K);
+      size += ALIGN(alignedw * (unsigned int)ALIGN(height / 2, 32), SIZE_8K);
+      break;
+    case HAL_PIXEL_FORMAT_YV12:
+      if ((format == HAL_PIXEL_FORMAT_YV12) && ((width & 1) || (height & 1))) {
+        ALOGE("w or h is odd for the YV12 format");
+        return 0;
+      }
+      size = alignedw * alignedh + (ALIGN(alignedw / 2, 16) * (alignedh / 2)) * 2;
+      size = ALIGN(size, (unsigned int)SIZE_4K);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP:
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+      size = ALIGN((alignedw * alignedh) + (alignedw * alignedh) / 2 + 1, SIZE_4K);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010:
+      size = ALIGN((alignedw * alignedh * 2) + (alignedw * alignedh) + 1, SIZE_4K);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_422_SP:
+    case HAL_PIXEL_FORMAT_YCrCb_422_SP:
+    case HAL_PIXEL_FORMAT_YCbCr_422_I:
+    case HAL_PIXEL_FORMAT_YCrCb_422_I:
+    case HAL_PIXEL_FORMAT_CbYCrY_422_I:
+      if (width & 1) {
+        ALOGE("width is odd for the YUV422_SP format");
+        return 0;
+      }
+      size = ALIGN(alignedw * alignedh * 2, SIZE_4K);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:
+      size = VENUS_BUFFER_SIZE(COLOR_FMT_NV12, width, height);
+      break;
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP_VENUS:
+      size = VENUS_BUFFER_SIZE(COLOR_FMT_NV21, width, height);
+      break;
+    case HAL_PIXEL_FORMAT_BLOB:
+    case HAL_PIXEL_FORMAT_RAW_OPAQUE:
+      if (height != 1) {
+        ALOGE("%s: Buffers with HAL_PIXEL_FORMAT_BLOB must have height 1 ", __FUNCTION__);
+        return 0;
+      }
+      size = (unsigned int)width;
+      break;
+    case HAL_PIXEL_FORMAT_NV21_ZSL:
+      size = ALIGN((alignedw * alignedh) + (alignedw * alignedh) / 2, SIZE_4K);
+      break;
+    default:
+      ALOGE("%s: Unrecognized pixel format: 0x%x", __FUNCTION__, format);
+      return 0;
+  }
+
+  return size;
+}
+
+void GetBufferSizeAndDimensions(const BufferInfo &info, unsigned int *size,
+                                unsigned int *alignedw, unsigned int *alignedh) {
+  GetAlignedWidthAndHeight(info, alignedw, alignedh);
+  *size = GetSize(info, *alignedw, *alignedh);
+}
+
+void GetYuvUbwcSPPlaneInfo(uint64_t base, uint32_t width, uint32_t height,
+                           int color_format, struct android_ycbcr *ycbcr) {
+  // UBWC buffer has these 4 planes in the following sequence:
+  // Y_Meta_Plane, Y_Plane, UV_Meta_Plane, UV_Plane
+  unsigned int y_meta_stride, y_meta_height, y_meta_size;
+  unsigned int y_stride, y_height, y_size;
+  unsigned int c_meta_stride, c_meta_height, c_meta_size;
+  unsigned int alignment = 4096;
+
+  y_meta_stride = VENUS_Y_META_STRIDE(color_format, INT(width));
+  y_meta_height = VENUS_Y_META_SCANLINES(color_format, INT(height));
+  y_meta_size = ALIGN((y_meta_stride * y_meta_height), alignment);
+
+  y_stride = VENUS_Y_STRIDE(color_format, INT(width));
+  y_height = VENUS_Y_SCANLINES(color_format, INT(height));
+  y_size = ALIGN((y_stride * y_height), alignment);
+
+  c_meta_stride = VENUS_UV_META_STRIDE(color_format, INT(width));
+  c_meta_height = VENUS_UV_META_SCANLINES(color_format, INT(height));
+  c_meta_size = ALIGN((c_meta_stride * c_meta_height), alignment);
+
+  ycbcr->y = reinterpret_cast<void *>(base + y_meta_size);
+  ycbcr->cb = reinterpret_cast<void *>(base + y_meta_size + y_size + c_meta_size);
+  ycbcr->cr = reinterpret_cast<void *>(base + y_meta_size + y_size + c_meta_size + 1);
+  ycbcr->ystride = y_stride;
+  ycbcr->cstride = VENUS_UV_STRIDE(color_format, INT(width));
+}
+
+void GetYuvUbwcInterlacedSPPlaneInfo(uint64_t base, uint32_t width, uint32_t height,
+                                     int color_format, struct android_ycbcr *ycbcr) {
+  unsigned int uv_stride, uv_height, uv_size;
+  unsigned int alignment = 4096;
+  uint64_t field_base;
+
+  // UBWC interlaced has top-bottom field layout with each field as
+  // 4-plane NV12_UBWC with width = image_width & height = image_height / 2.
+  // Client passed ycbcr argument is ptr to struct android_ycbcr[2].
+  // Plane info to be filled for each field separately.
+  height = (height + 1) >> 1;
+  uv_stride = VENUS_UV_STRIDE(color_format, INT(width));
+  uv_height = VENUS_UV_SCANLINES(color_format, INT(height));
+  uv_size = ALIGN((uv_stride * uv_height), alignment);
+
+  field_base = base;
+  GetYuvUbwcSPPlaneInfo(field_base, width, height, COLOR_FMT_NV12_UBWC, &ycbcr[0]);
+
+  field_base = reinterpret_cast<uint64_t>(ycbcr[0].cb) + uv_size;
+  GetYuvUbwcSPPlaneInfo(field_base, width, height, COLOR_FMT_NV12_UBWC, &ycbcr[1]);
+}
+
+void GetYuvSPPlaneInfo(uint64_t base, uint32_t width, uint32_t height, uint32_t bpp,
+                       struct android_ycbcr *ycbcr) {
+  unsigned int ystride, cstride;
+
+  ystride = cstride = UINT(width) * bpp;
+  ycbcr->y = reinterpret_cast<void *>(base);
+  ycbcr->cb = reinterpret_cast<void *>(base + ystride * UINT(height));
+  ycbcr->cr = reinterpret_cast<void *>(base + ystride * UINT(height) + 1);
+  ycbcr->ystride = ystride;
+  ycbcr->cstride = cstride;
+  ycbcr->chroma_step = 2 * bpp;
+}
+
+int GetYUVPlaneInfo(const private_handle_t *hnd, struct android_ycbcr *ycbcr) {
+  int err = 0;
+  uint32_t width = UINT(hnd->width);
+  uint32_t height = UINT(hnd->height);
+  int format = hnd->format;
+  gralloc1_producer_usage_t prod_usage = hnd->GetProducerUsage();
+  gralloc1_consumer_usage_t cons_usage = hnd->GetConsumerUsage();
+  unsigned int ystride, cstride;
+  bool interlaced = false;
+
+  memset(ycbcr->reserved, 0, sizeof(ycbcr->reserved));
+
+  // Check if UBWC buffer has been rendered in linear format.
+  int linear_format = 0;
+  if (getMetaData(const_cast<private_handle_t *>(hnd),
+                  GET_LINEAR_FORMAT, &linear_format) == 0) {
+      format = INT(linear_format);
+  }
+
+  // Check metadata if the geometry has been updated.
+  BufferDim_t buffer_dim;
+  if (getMetaData(const_cast<private_handle_t *>(hnd),
+                  GET_BUFFER_GEOMETRY, &buffer_dim) == 0) {
+    int usage = 0;
+    if (hnd->flags & private_handle_t::PRIV_FLAGS_UBWC_ALIGNED) {
+      usage = GRALLOC1_PRODUCER_USAGE_PRIVATE_ALLOC_UBWC;
+    }
+
+    BufferInfo info(buffer_dim.sliceWidth, buffer_dim.sliceHeight, format,
+                    prod_usage, cons_usage);
+    GetAlignedWidthAndHeight(info, &width, &height);
+  }
+
+  // Check metadata for interlaced content.
+  int interlace_flag = 0;
+  if (getMetaData(const_cast<private_handle_t *>(hnd),
+                  GET_PP_PARAM_INTERLACED, &interlace_flag) != 0) {
+    interlaced = interlace_flag;
+  }
+
+  // Get the chroma offsets from the handle width/height. We take advantage
+  // of the fact the width _is_ the stride
+  switch (format) {
+    // Semiplanar
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP:
+    case HAL_PIXEL_FORMAT_YCbCr_422_SP:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:
+      // Same as YCbCr_420_SP_VENUS
+      GetYuvSPPlaneInfo(hnd->base, width, height, 1, ycbcr);
+      break;
+
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010:
+      GetYuvSPPlaneInfo(hnd->base, width, height, 2, ycbcr);
+      break;
+
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC:
+      if (!interlaced) {
+        GetYuvUbwcSPPlaneInfo(hnd->base, width, height, COLOR_FMT_NV12_UBWC, ycbcr);
+      } else {
+        GetYuvUbwcInterlacedSPPlaneInfo(hnd->base, width, height, COLOR_FMT_NV12_UBWC, ycbcr);
+      }
+      ycbcr->chroma_step = 2;
+      break;
+
+    case HAL_PIXEL_FORMAT_YCbCr_420_TP10_UBWC:
+      GetYuvUbwcSPPlaneInfo(hnd->base, width, height, COLOR_FMT_NV12_BPP10_UBWC, ycbcr);
+      ycbcr->chroma_step = 3;
+      break;
+
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010_UBWC:
+      GetYuvUbwcSPPlaneInfo(hnd->base, width, height, COLOR_FMT_P010_UBWC, ycbcr);
+      ycbcr->chroma_step = 4;
+      break;
+
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+    case HAL_PIXEL_FORMAT_YCrCb_422_SP:
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP_ADRENO:
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_NV21_ZSL:
+    case HAL_PIXEL_FORMAT_RAW16:
+    case HAL_PIXEL_FORMAT_Y16:
+    case HAL_PIXEL_FORMAT_RAW10:
+    case HAL_PIXEL_FORMAT_RAW8:
+    case HAL_PIXEL_FORMAT_Y8:
+      GetYuvSPPlaneInfo(hnd->base, width, height, 1, ycbcr);
+      std::swap(ycbcr->cb, ycbcr->cr);
+      break;
+
+      // Planar
+    case HAL_PIXEL_FORMAT_YV12:
+      ystride = width;
+      cstride = ALIGN(width / 2, 16);
+      ycbcr->y = reinterpret_cast<void *>(hnd->base);
+      ycbcr->cr = reinterpret_cast<void *>(hnd->base + ystride * height);
+      ycbcr->cb = reinterpret_cast<void *>(hnd->base + ystride * height + cstride * height / 2);
+      ycbcr->ystride = ystride;
+      ycbcr->cstride = cstride;
+      ycbcr->chroma_step = 1;
+      break;
+    case HAL_PIXEL_FORMAT_CbYCrY_422_I:
+      ystride = width * 2;
+      cstride = 0;
+      ycbcr->y  = reinterpret_cast<void *>(hnd->base);
+      ycbcr->cr = NULL;
+      ycbcr->cb = NULL;
+      ycbcr->ystride = ystride;
+      ycbcr->cstride = 0;
+      ycbcr->chroma_step = 0;
+      break;
+      // Unsupported formats
+    case HAL_PIXEL_FORMAT_YCbCr_422_I:
+    case HAL_PIXEL_FORMAT_YCrCb_422_I:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_TILED:
+    default:
+      ALOGD("%s: Invalid format passed: 0x%x", __FUNCTION__, format);
+      err = -EINVAL;
+  }
+
+  return err;
+}
+
+// Explicitly defined UBWC formats
+bool IsUBwcFormat(int format) {
+  switch (format) {
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC:
+    case HAL_PIXEL_FORMAT_YCbCr_420_TP10_UBWC:
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010_UBWC:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool IsUBwcSupported(int format) {
+  // Existing HAL formats with UBWC support
+  switch (format) {
+    case HAL_PIXEL_FORMAT_BGR_565:
+    case HAL_PIXEL_FORMAT_RGBA_8888:
+    case HAL_PIXEL_FORMAT_RGBX_8888:
+    case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_RGBA_1010102:
+    case HAL_PIXEL_FORMAT_RGBX_1010102:
+      return true;
+    default:
+      break;
+  }
+
+  return false;
+}
+
+bool IsUBwcEnabled(int format, gralloc1_producer_usage_t prod_usage,
+                   gralloc1_consumer_usage_t cons_usage) {
+  // Allow UBWC, if client is using an explicitly defined UBWC pixel format.
+  if (IsUBwcFormat(format)) {
+    return true;
+  }
+
+  // Allow UBWC, if an OpenGL client sets UBWC usage flag and GPU plus MDP
+  // support the format. OR if a non-OpenGL client like Rotator, sets UBWC
+  // usage flag and MDP supports the format.
+  if ((prod_usage & GRALLOC1_PRODUCER_USAGE_PRIVATE_ALLOC_UBWC) && IsUBwcSupported(format)) {
+    bool enable = true;
+    // Query GPU for UBWC only if buffer is intended to be used by GPU.
+    if ((cons_usage & GRALLOC1_CONSUMER_USAGE_GPU_TEXTURE) ||
+        (prod_usage & GRALLOC1_PRODUCER_USAGE_GPU_RENDER_TARGET)) {
+      if (AdrenoMemInfo::GetInstance()) {
+        enable = AdrenoMemInfo::GetInstance()->IsUBWCSupportedByGPU(format);
+      }
+    }
+
+    // Allow UBWC, only if CPU usage flags are not set
+    if (enable && !(CpuCanAccess(prod_usage, cons_usage))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void GetYuvUBwcWidthAndHeight(int width, int height, int format, unsigned int *aligned_w,
+                              unsigned int *aligned_h) {
+  switch (format) {
+    case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC:
+      *aligned_w = VENUS_Y_STRIDE(COLOR_FMT_NV12_UBWC, width);
+      *aligned_h = VENUS_Y_SCANLINES(COLOR_FMT_NV12_UBWC, height);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_TP10_UBWC:
+      // The macro returns the stride which is 4/3 times the width, hence * 3/4
+      *aligned_w = (VENUS_Y_STRIDE(COLOR_FMT_NV12_BPP10_UBWC, width) * 3) / 4;
+      *aligned_h = VENUS_Y_SCANLINES(COLOR_FMT_NV12_BPP10_UBWC, height);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010_UBWC:
+      // The macro returns the stride which is 2 times the width, hence / 2
+      *aligned_w = (VENUS_Y_STRIDE(COLOR_FMT_P010_UBWC, width) / 2);
+      *aligned_h = VENUS_Y_SCANLINES(COLOR_FMT_P010_UBWC, height);
+      break;
+    default:
+      ALOGE("%s: Unsupported pixel format: 0x%x", __FUNCTION__, format);
+      *aligned_w = 0;
+      *aligned_h = 0;
+      break;
+  }
+}
+
+void GetRgbUBwcBlockSize(uint32_t bpp, int *block_width, int *block_height) {
+  *block_width = 0;
+  *block_height = 0;
+
+  switch (bpp) {
+    case 2:
+    case 4:
+      *block_width = 16;
+      *block_height = 4;
+      break;
+    case 8:
+      *block_width = 8;
+      *block_height = 4;
+      break;
+    case 16:
+      *block_width = 4;
+      *block_height = 4;
+      break;
+    default:
+      ALOGE("%s: Unsupported bpp: %d", __FUNCTION__, bpp);
+      break;
+  }
+}
+
+unsigned int GetRgbUBwcMetaBufferSize(int width, int height, uint32_t bpp) {
+  unsigned int size = 0;
+  int meta_width, meta_height;
+  int block_width, block_height;
+
+  GetRgbUBwcBlockSize(bpp, &block_width, &block_height);
+  if (!block_width || !block_height) {
+    ALOGE("%s: Unsupported bpp: %d", __FUNCTION__, bpp);
+    return size;
+  }
+
+  // Align meta buffer height to 16 blocks
+  meta_height = ALIGN(((height + block_height - 1) / block_height), 16);
+
+  // Align meta buffer width to 64 blocks
+  meta_width = ALIGN(((width + block_width - 1) / block_width), 64);
+
+  // Align meta buffer size to 4K
+  size = (unsigned int)ALIGN((meta_width * meta_height), 4096);
+
+  return size;
+}
+
+unsigned int GetUBwcSize(int width, int height, int format, unsigned int alignedw,
+                         unsigned int alignedh) {
+  unsigned int size = 0;
+  uint32_t bpp = 0;
+  switch (format) {
+    case HAL_PIXEL_FORMAT_BGR_565:
+    case HAL_PIXEL_FORMAT_RGBA_8888:
+    case HAL_PIXEL_FORMAT_RGBX_8888:
+    case HAL_PIXEL_FORMAT_RGBA_1010102:
+    case HAL_PIXEL_FORMAT_RGBX_1010102:
+      bpp = GetBppForUncompressedRGB(format);
+      size = alignedw * alignedh * bpp;
+      size += GetRgbUBwcMetaBufferSize(width, height, bpp);
+      break;
+    case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC:
+      size = VENUS_BUFFER_SIZE(COLOR_FMT_NV12_UBWC, width, height);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_TP10_UBWC:
+      size = VENUS_BUFFER_SIZE(COLOR_FMT_NV12_BPP10_UBWC, width, height);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010_UBWC:
+      size = VENUS_BUFFER_SIZE(COLOR_FMT_P010_UBWC, width, height);
+      break;
+    default:
+      ALOGE("%s: Unsupported pixel format: 0x%x", __FUNCTION__, format);
+      break;
+  }
+
+  return size;
+}
+
+int GetRgbDataAddress(private_handle_t *hnd, void **rgb_data) {
+  int err = 0;
+
+  // This api is for RGB* formats
+  if (!gralloc1::IsUncompressedRGBFormat(hnd->format)) {
+    return -EINVAL;
+  }
+
+  // linear buffer, nothing to do further
+  if (!(hnd->flags & private_handle_t::PRIV_FLAGS_UBWC_ALIGNED)) {
+    *rgb_data = reinterpret_cast<void *>(hnd->base);
+    return err;
+  }
+
+  unsigned int meta_size = 0;
+  uint32_t bpp = GetBppForUncompressedRGB(hnd->format);
+  switch (hnd->format) {
+    case HAL_PIXEL_FORMAT_BGR_565:
+    case HAL_PIXEL_FORMAT_RGBA_8888:
+    case HAL_PIXEL_FORMAT_RGBX_8888:
+    case HAL_PIXEL_FORMAT_RGBA_1010102:
+    case HAL_PIXEL_FORMAT_RGBX_1010102:
+      meta_size = GetRgbUBwcMetaBufferSize(hnd->width, hnd->height, bpp);
+      break;
+    default:
+      ALOGE("%s:Unsupported RGB format: 0x%x", __FUNCTION__, hnd->format);
+      err = -EINVAL;
+      break;
+  }
+  *rgb_data = reinterpret_cast<void *>(hnd->base + meta_size);
+
+  return err;
+}
+
+void GetAlignedWidthAndHeight(const BufferInfo &info, unsigned int *alignedw,
+                              unsigned int *alignedh) {
+  int width = info.width;
+  int height = info.height;
+  int format = info.format;
+  gralloc1_producer_usage_t prod_usage = info.prod_usage;
+  gralloc1_consumer_usage_t cons_usage = info.cons_usage;
+
+  // Currently surface padding is only computed for RGB* surfaces.
+  bool ubwc_enabled = IsUBwcEnabled(format, prod_usage, cons_usage);
+  int tile = ubwc_enabled;
+
+  if (IsUncompressedRGBFormat(format)) {
+    if (AdrenoMemInfo::GetInstance()) {
+      AdrenoMemInfo::GetInstance()->AlignUnCompressedRGB(width, height, format, tile, alignedw,
+                                                         alignedh);
+    }
+    return;
+  }
+
+  if (ubwc_enabled) {
+    GetYuvUBwcWidthAndHeight(width, height, format, alignedw, alignedh);
+    return;
+  }
+
+  if (IsCompressedRGBFormat(format)) {
+    if (AdrenoMemInfo::GetInstance()) {
+      AdrenoMemInfo::GetInstance()->AlignCompressedRGB(width, height, format, alignedw, alignedh);
+    }
+    return;
+  }
+
+  int aligned_w = width;
+  int aligned_h = height;
+  unsigned int alignment = 32;
+
+  // Below should be only YUV family
+  switch (format) {
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP:
+      if (AdrenoMemInfo::GetInstance() == nullptr) {
+        return;
+      }
+      alignment = AdrenoMemInfo::GetInstance()->GetGpuPixelAlignment();
+      aligned_w = ALIGN(width, alignment);
+      break;
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP_ADRENO:
+      aligned_w = ALIGN(width, alignment);
+      break;
+    case HAL_PIXEL_FORMAT_RAW16:
+    case HAL_PIXEL_FORMAT_Y16:
+    case HAL_PIXEL_FORMAT_Y8:
+      aligned_w = ALIGN(width, 16);
+      break;
+    case HAL_PIXEL_FORMAT_RAW12:
+      aligned_w = ALIGN(width * 12 / 8, 8);
+      break;
+    case HAL_PIXEL_FORMAT_RAW10:
+      aligned_w = ALIGN(width * 10 / 8, 8);
+      break;
+    case HAL_PIXEL_FORMAT_RAW8:
+      aligned_w = ALIGN(width, 8);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_TILED:
+      aligned_w = ALIGN(width, 128);
+      break;
+    case HAL_PIXEL_FORMAT_YV12:
+    case HAL_PIXEL_FORMAT_YCbCr_422_SP:
+    case HAL_PIXEL_FORMAT_YCrCb_422_SP:
+    case HAL_PIXEL_FORMAT_YCbCr_422_I:
+    case HAL_PIXEL_FORMAT_YCrCb_422_I:
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010:
+      aligned_w = ALIGN(width, 16);
+      break;
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:
+      aligned_w = INT(VENUS_Y_STRIDE(COLOR_FMT_NV12, width));
+      aligned_h = INT(VENUS_Y_SCANLINES(COLOR_FMT_NV12, height));
+      break;
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP_VENUS:
+      aligned_w = INT(VENUS_Y_STRIDE(COLOR_FMT_NV21, width));
+      aligned_h = INT(VENUS_Y_SCANLINES(COLOR_FMT_NV21, height));
+      break;
+    case HAL_PIXEL_FORMAT_BLOB:
+    case HAL_PIXEL_FORMAT_RAW_OPAQUE:
+      break;
+    case HAL_PIXEL_FORMAT_NV21_ZSL:
+      aligned_w = ALIGN(width, 64);
+      aligned_h = ALIGN(height, 64);
+      break;
+    default:
+      break;
+  }
+
+  *alignedw = (unsigned int)aligned_w;
+  *alignedh = (unsigned int)aligned_h;
+}
+
+int GetBufferLayout(private_handle_t *hnd, uint32_t stride[4],
+                    uint32_t offset[4], uint32_t *num_planes) {
+  if (!hnd || !stride || !offset || !num_planes) {
+    return -EINVAL;
+  }
+
+  struct android_ycbcr yuvInfo = {};
+  *num_planes = 1;
+  stride[0] = 0;
+
+  switch (hnd->format) {
+    case HAL_PIXEL_FORMAT_RGB_565:
+    case HAL_PIXEL_FORMAT_BGR_565:
+    case HAL_PIXEL_FORMAT_RGBA_5551:
+    case HAL_PIXEL_FORMAT_RGBA_4444:
+      stride[0] = static_cast<uint32_t>(hnd->width * 2);
+      break;
+    case HAL_PIXEL_FORMAT_RGB_888:
+      stride[0] = static_cast<uint32_t>(hnd->width * 3);
+      break;
+    case HAL_PIXEL_FORMAT_RGBA_8888:
+    case HAL_PIXEL_FORMAT_BGRA_8888:
+    case HAL_PIXEL_FORMAT_RGBX_8888:
+    case HAL_PIXEL_FORMAT_BGRX_8888:
+    case HAL_PIXEL_FORMAT_RGBA_1010102:
+    case HAL_PIXEL_FORMAT_ARGB_2101010:
+    case HAL_PIXEL_FORMAT_RGBX_1010102:
+    case HAL_PIXEL_FORMAT_XRGB_2101010:
+    case HAL_PIXEL_FORMAT_BGRA_1010102:
+    case HAL_PIXEL_FORMAT_ABGR_2101010:
+    case HAL_PIXEL_FORMAT_BGRX_1010102:
+    case HAL_PIXEL_FORMAT_XBGR_2101010:
+      stride[0] = static_cast<uint32_t>(hnd->width * 4);
+      break;
+  }
+
+  // Format is RGB
+  if (stride[0]) {
+    return 0;
+  }
+
+  (*num_planes)++;
+  int ret = GetYUVPlaneInfo(hnd, &yuvInfo);
+  if (ret < 0) {
+    ALOGE("%s failed", __FUNCTION__);
+    return ret;
+  }
+
+  stride[0] = static_cast<uint32_t>(yuvInfo.ystride);
+  offset[0] = static_cast<uint32_t>(reinterpret_cast<uint64_t>(yuvInfo.y) - hnd->base);
+  stride[1] = static_cast<uint32_t>(yuvInfo.cstride);
+  switch (hnd->format) {
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP:
+    case HAL_PIXEL_FORMAT_YCbCr_422_SP:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_NV12_ENCODEABLE:
+    case HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC:
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010:
+    case HAL_PIXEL_FORMAT_YCbCr_420_TP10_UBWC:
+    case HAL_PIXEL_FORMAT_YCbCr_420_P010_UBWC:
+      offset[1] = static_cast<uint32_t>(reinterpret_cast<uint64_t>(yuvInfo.cb) - hnd->base);
+      break;
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP:
+    case HAL_PIXEL_FORMAT_YCrCb_420_SP_VENUS:
+    case HAL_PIXEL_FORMAT_YCrCb_422_SP:
+      offset[1] = static_cast<uint32_t>(reinterpret_cast<uint64_t>(yuvInfo.cr) - hnd->base);
+      break;
+    case HAL_PIXEL_FORMAT_YV12:
+      offset[1] = static_cast<uint32_t>(reinterpret_cast<uint64_t>(yuvInfo.cr) - hnd->base);
+      stride[2] = static_cast<uint32_t>(yuvInfo.cstride);
+      offset[2] = static_cast<uint32_t>(reinterpret_cast<uint64_t>(yuvInfo.cb) - hnd->base);
+      (*num_planes)++;
+      break;
+    default:
+      ALOGW("%s: Unsupported format", __FUNCTION__);
+      ret = -EINVAL;
+  }
+
+  if (hnd->flags & private_handle_t::PRIV_FLAGS_UBWC_ALIGNED) {
+    std::fill(offset, offset + 4, 0);
+  }
+
+  return 0;
+}
+
+}  // namespace gralloc1

--- a/gralloc1/gr_utils.h
+++ b/gralloc1/gr_utils.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2011-2016, The Linux Foundation. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of The Linux Foundation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GR_UTILS_H__
+#define __GR_UTILS_H__
+
+#include "gralloc_priv.h"
+
+#define SZ_2M 0x200000
+#define SZ_1M 0x100000
+#define SZ_4K 0x1000
+
+#define SIZE_4K 4096
+#define SIZE_8K 4096
+
+#define INT(exp) static_cast<int>(exp)
+#define UINT(exp) static_cast<unsigned int>(exp)
+
+namespace gralloc1 {
+
+struct BufferInfo {
+  BufferInfo(int w, int h, int f, gralloc1_producer_usage_t prod = GRALLOC1_PRODUCER_USAGE_NONE,
+             gralloc1_consumer_usage_t cons = GRALLOC1_CONSUMER_USAGE_NONE) : width(w), height(h),
+    format(f), prod_usage(prod), cons_usage(cons) {}
+  int width;
+  int height;
+  int format;
+  gralloc1_producer_usage_t prod_usage;
+  gralloc1_consumer_usage_t cons_usage;
+};
+
+template <class Type1, class Type2>
+inline Type1 ALIGN(Type1 x, Type2 align) {
+  return (Type1)((x + (Type1)align - 1) & ~((Type1)align - 1));
+}
+
+bool IsCompressedRGBFormat(int format);
+bool IsUncompressedRGBFormat(int format);
+uint32_t GetBppForUncompressedRGB(int format);
+bool CpuCanAccess(gralloc1_producer_usage_t prod_usage, gralloc1_consumer_usage_t cons_usage);
+bool CpuCanRead(gralloc1_producer_usage_t prod_usage, gralloc1_consumer_usage_t cons_usage);
+bool CpuCanWrite(gralloc1_producer_usage_t prod_usage);
+unsigned int GetSize(const BufferInfo &d, unsigned int alignedw, unsigned int alignedh);
+void GetBufferSizeAndDimensions(const BufferInfo &d, unsigned int *size,
+                                unsigned int *alignedw, unsigned int *alignedh);
+void GetAlignedWidthAndHeight(const BufferInfo &d, unsigned int *aligned_w,
+                              unsigned int *aligned_h);
+int GetYUVPlaneInfo(const private_handle_t *hnd, struct android_ycbcr *ycbcr);
+int GetRgbDataAddress(private_handle_t *hnd, void **rgb_data);
+bool IsUBwcFormat(int format);
+bool IsUBwcSupported(int format);
+bool IsUBwcEnabled(int format, gralloc1_producer_usage_t prod_usage,
+                   gralloc1_consumer_usage_t cons_usage);
+void GetYuvUBwcWidthAndHeight(int width, int height, int format, unsigned int *aligned_w,
+                              unsigned int *aligned_h);
+void GetYuvSPPlaneInfo(uint64_t base, uint32_t width, uint32_t height, uint32_t bpp,
+                       struct android_ycbcr *ycbcr);
+void GetYuvUbwcSPPlaneInfo(uint64_t base, uint32_t width, uint32_t height, int color_format,
+                           struct android_ycbcr *ycbcr);
+void GetYuvUbwcInterlacedSPPlaneInfo(uint64_t base, uint32_t width, uint32_t height,
+                                     int color_format, struct android_ycbcr *ycbcr);
+void GetRgbUBwcBlockSize(uint32_t bpp, int *block_width, int *block_height);
+unsigned int GetRgbUBwcMetaBufferSize(int width, int height, uint32_t bpp);
+unsigned int GetUBwcSize(int width, int height, int format, unsigned int alignedw,
+                         unsigned int alignedh);
+int GetBufferLayout(private_handle_t *hnd, uint32_t stride[4],
+                    uint32_t offset[4], uint32_t *num_planes);
+}  // namespace gralloc1
+
+#endif  // __GR_UTILS_H__

--- a/gralloc1/gralloc_priv.h
+++ b/gralloc1/gralloc_priv.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2011-2018, The Linux Foundation. All rights reserved.
+ * Not a Contribution
+ *
+ * Copyright (C) 2008 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __GRALLOC_PRIV_H__
+#define __GRALLOC_PRIV_H__
+
+#include <unistd.h>
+#include "gr_priv_handle.h"
+
+#define GRALLOC_PROP_PREFIX  "vendor.gralloc."
+#define GRALLOC_PROP(prop_name) GRALLOC_PROP_PREFIX prop_name
+
+#define DISABLE_UBWC_PROP                    GRALLOC_PROP("disable_ubwc")
+#define ENABLE_FB_UBWC_PROP                  GRALLOC_PROP("enable_fb_ubwc")
+#define MAP_FB_MEMORY_PROP                   GRALLOC_PROP("map_fb_memory")
+
+#define ROUND_UP_PAGESIZE(x) roundUpToPageSize(x)
+inline int roundUpToPageSize(int x) {
+    return (x + (getpagesize()-1)) & ~(getpagesize()-1);
+}
+
+/* Gralloc usage bits indicating the type of allocation that should be used */
+/* Refer gralloc1_producer_usage_t & gralloc1_consumer_usage-t in gralloc1.h */
+
+/* Producer flags */
+/* Non linear, Universal Bandwidth Compression */
+#define GRALLOC1_PRODUCER_USAGE_PRIVATE_ALLOC_UBWC  GRALLOC1_PRODUCER_USAGE_PRIVATE_0
+
+/* Set this for allocating uncached memory (using O_DSYNC),
+ * cannot be used with noncontiguous heaps */
+#define GRALLOC1_PRODUCER_USAGE_PRIVATE_UNCACHED    GRALLOC1_PRODUCER_USAGE_PRIVATE_1
+
+/* CAMERA heap is a carveout heap for camera, is not secured */
+#define GRALLOC1_PRODUCER_USAGE_PRIVATE_CAMERA_HEAP GRALLOC1_PRODUCER_USAGE_PRIVATE_2
+
+/* ADSP heap is a carveout heap, is not secured */
+#define GRALLOC1_PRODUCER_USAGE_PRIVATE_ADSP_HEAP   GRALLOC1_PRODUCER_USAGE_PRIVATE_3
+
+/* IOMMU heap comes from manually allocated pages, can be cached/uncached, is not secured */
+#define GRALLOC1_PRODUCER_USAGE_PRIVATE_IOMMU_HEAP  GRALLOC1_PRODUCER_USAGE_PRIVATE_4
+
+/* MM heap is a carveout heap for video, can be secured */
+#define GRALLOC1_PRODUCER_USAGE_PRIVATE_MM_HEAP     GRALLOC1_PRODUCER_USAGE_PRIVATE_5
+
+/* Use legacy ZSL definition until we know the correct usage on gralloc1 */
+#define GRALLOC1_PRODUCER_USAGE_PRIVATE_CAMERA_ZSL  GRALLOC_USAGE_HW_CAMERA_ZSL
+
+
+/* Consumer flags */
+/* TODO(user): Fix when producer and consumer flags are actually separated */
+/* This flag is set for WFD usecase */
+#define GRALLOC1_CONSUMER_USAGE_PRIVATE_WFD            (UINT32_C(1) << 21)
+
+/* This flag is used for SECURE display usecase */
+#define GRALLOC1_CONSUMER_USAGE_PRIVATE_SECURE_DISPLAY (UINT32_C(1) << 31)
+
+/* Buffer content should be displayed on a primary display only */
+#define GRALLOC1_CONSUMER_USAGE_PRIVATE_INTERNAL_ONLY  0x04000000
+
+/* Buffer content should be displayed on an external display only */
+#define GRALLOC1_CONSUMER_USAGE_PRIVATE_EXTERNAL_ONLY  0x08000000
+
+
+/* Legacy gralloc0.x definitions */
+/* Some clients may still be using the old flags */
+#define GRALLOC_USAGE_PRIVATE_ALLOC_UBWC GRALLOC1_PRODUCER_USAGE_PRIVATE_ALLOC_UBWC
+#define GRALLOC_USAGE_PRIVATE_UNCACHED GRALLOC1_PRODUCER_USAGE_PRIVATE_UNCACHED
+#define GRALLOC_USAGE_PRIVATE_IOMMU_HEAP GRALLOC1_PRODUCER_USAGE_PRIVATE_IOMMU_HEAP
+#define GRALLOC_USAGE_PRIVATE_WFD GRALLOC1_CONSUMER_USAGE_PRIVATE_WFD
+#define GRALLOC_USAGE_PRIVATE_CAMERA_HEAP GRALLOC1_PRODUCER_USAGE_PRIVATE_CAMERA_HEAP
+#define GRALLOC_USAGE_PRIVATE_SECURE_DISPLAY GRALLOC1_CONSUMER_USAGE_PRIVATE_SECURE_DISPLAY
+#define GRALLOC_USAGE_PRIVATE_MM_HEAP 0x0
+
+
+
+// for PERFORM API :
+#define GRALLOC_MODULE_PERFORM_CREATE_HANDLE_FROM_BUFFER 1
+#define GRALLOC_MODULE_PERFORM_GET_STRIDE 2
+#define GRALLOC_MODULE_PERFORM_GET_CUSTOM_STRIDE_FROM_HANDLE 3
+#define GRALLOC_MODULE_PERFORM_GET_CUSTOM_STRIDE_AND_HEIGHT_FROM_HANDLE 4
+#define GRALLOC_MODULE_PERFORM_GET_ATTRIBUTES 5
+#define GRALLOC_MODULE_PERFORM_GET_COLOR_SPACE_FROM_HANDLE 6
+#define GRALLOC_MODULE_PERFORM_GET_YUV_PLANE_INFO 7
+#define GRALLOC_MODULE_PERFORM_GET_MAP_SECURE_BUFFER_INFO 8
+#define GRALLOC_MODULE_PERFORM_GET_UBWC_FLAG 9
+#define GRALLOC_MODULE_PERFORM_GET_RGB_DATA_ADDRESS 10
+#define GRALLOC_MODULE_PERFORM_GET_IGC 11
+#define GRALLOC_MODULE_PERFORM_SET_IGC 12
+#define GRALLOC_MODULE_PERFORM_SET_SINGLE_BUFFER_MODE 13
+#define GRALLOC1_MODULE_PERFORM_GET_BUFFER_SIZE_AND_DIMENSIONS 14
+#define GRALLOC1_MODULE_PERFORM_ALLOCATE_BUFFER 15
+#define GRALLOC1_MODULE_PERFORM_GET_INTERLACE_FLAG 16
+
+// OEM specific HAL formats
+#define HAL_PIXEL_FORMAT_RGBA_5551 6
+#define HAL_PIXEL_FORMAT_RGBA_4444 7
+#define HAL_PIXEL_FORMAT_NV12_ENCODEABLE 0x102
+#define HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS 0x7FA30C04
+#define HAL_PIXEL_FORMAT_YCbCr_420_SP_TILED 0x7FA30C03
+#define HAL_PIXEL_FORMAT_YCbCr_420_SP 0x109
+#define HAL_PIXEL_FORMAT_YCrCb_420_SP_ADRENO 0x7FA30C01
+#define HAL_PIXEL_FORMAT_YCrCb_422_SP 0x10B
+#define HAL_PIXEL_FORMAT_R_8 0x10D
+#define HAL_PIXEL_FORMAT_RG_88 0x10E
+#define HAL_PIXEL_FORMAT_YCbCr_444_SP 0x10F
+#define HAL_PIXEL_FORMAT_YCrCb_444_SP 0x110
+#define HAL_PIXEL_FORMAT_YCrCb_422_I 0x111
+#define HAL_PIXEL_FORMAT_BGRX_8888 0x112
+#define HAL_PIXEL_FORMAT_NV21_ZSL 0x113
+#define HAL_PIXEL_FORMAT_YCrCb_420_SP_VENUS 0x114
+#define HAL_PIXEL_FORMAT_BGR_565 0x115
+#define HAL_PIXEL_FORMAT_RAW8 0x123
+
+// 10 bit
+#define HAL_PIXEL_FORMAT_ARGB_2101010 0x117
+#define HAL_PIXEL_FORMAT_RGBX_1010102 0x118
+#define HAL_PIXEL_FORMAT_XRGB_2101010 0x119
+#define HAL_PIXEL_FORMAT_BGRA_1010102 0x11A
+#define HAL_PIXEL_FORMAT_ABGR_2101010 0x11B
+#define HAL_PIXEL_FORMAT_BGRX_1010102 0x11C
+#define HAL_PIXEL_FORMAT_XBGR_2101010 0x11D
+#define HAL_PIXEL_FORMAT_YCbCr_420_P010 0x11F
+#define HAL_PIXEL_FORMAT_YCbCr_420_P010_UBWC 0x124
+#define HAL_PIXEL_FORMAT_YCbCr_420_P010_VENUS 0x7FA30C0A
+
+#define HAL_PIXEL_FORMAT_CbYCrY_422_I            0x120
+#define HAL_PIXEL_FORMAT_BGR_888                 0x121
+
+#define HAL_PIXEL_FORMAT_INTERLACE 0x180
+
+// v4l2_fourcc('Y', 'U', 'Y', 'L'). 24 bpp YUYV 4:2:2 10 bit per component
+#define HAL_PIXEL_FORMAT_YCbCr_422_I_10BIT 0x4C595559
+
+// v4l2_fourcc('Y', 'B', 'W', 'C'). 10 bit per component. This compressed
+// format reduces the memory access bandwidth
+#define HAL_PIXEL_FORMAT_YCbCr_422_I_10BIT_COMPRESSED 0x43574259
+
+// UBWC aligned Venus format
+#define HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC 0x7FA30C06
+#define HAL_PIXEL_FORMAT_YCbCr_420_TP10_UBWC     0x7FA30C09
+
+// Khronos ASTC formats
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_4x4_KHR 0x93B0
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_5x4_KHR 0x93B1
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_5x5_KHR 0x93B2
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_6x5_KHR 0x93B3
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_6x6_KHR 0x93B4
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_8x5_KHR 0x93B5
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_8x6_KHR 0x93B6
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_8x8_KHR 0x93B7
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_10x5_KHR 0x93B8
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_10x6_KHR 0x93B9
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_10x8_KHR 0x93BA
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_10x10_KHR 0x93BB
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_12x10_KHR 0x93BC
+#define HAL_PIXEL_FORMAT_COMPRESSED_RGBA_ASTC_12x12_KHR 0x93BD
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR 0x93D0
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR 0x93D1
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR 0x93D2
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR 0x93D3
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR 0x93D4
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR 0x93D5
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR 0x93D6
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR 0x93D7
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR 0x93D8
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR 0x93D9
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR 0x93DA
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR 0x93DB
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR 0x93DC
+#define HAL_PIXEL_FORMAT_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR 0x93DD
+
+/* possible values for inverse gamma correction */
+#define HAL_IGC_NOT_SPECIFIED 0
+#define HAL_IGC_s_RGB 1
+
+/* Color Space: Values maps to ColorSpace_t in qdMetadata.h */
+#define HAL_CSC_ITU_R_601         0
+#define HAL_CSC_ITU_R_601_FR      1
+#define HAL_CSC_ITU_R_709         2
+#define HAL_CSC_ITU_R_2020        3
+#define HAL_CSC_ITU_R_2020_FR     4
+
+/* possible formats for 3D content*/
+enum {
+  HAL_NO_3D = 0x0,
+  HAL_3D_SIDE_BY_SIDE_L_R = 0x1,
+  HAL_3D_SIDE_BY_SIDE_R_L = 0x2,
+  HAL_3D_TOP_BOTTOM = 0x4,
+  HAL_3D_IN_SIDE_BY_SIDE_L_R = 0x10000,  // unused legacy format
+};
+
+enum { BUFFER_TYPE_UI = 0, BUFFER_TYPE_VIDEO };
+
+#endif  // __GRALLOC_PRIV_H__

--- a/sdm/libs/hwc2/Android.mk
+++ b/sdm/libs/hwc2/Android.mk
@@ -45,8 +45,14 @@ LOCAL_SRC_FILES               := hwc_session.cpp \
                                  cpuhint.cpp \
                                  hwc_tonemapper.cpp \
                                  display_null.cpp \
-                                 hwc_socket_handler.cpp \
-                                 hwc_buffer_allocator.cpp
+                                 hwc_socket_handler.cpp
+
+ifeq ($(TARGET_USES_GRALLOC1), true)
+LOCAL_SRC_FILES               += hwc_buffer_allocator1.cpp
+LOCAL_CFLAGS += -DUSE_GRALLOC1
+else
+LOCAL_SRC_FILES               += hwc_buffer_allocator.cpp
+endif
 
 ifeq ($(TARGET_HAS_WIDE_COLOR_DISPLAY), true)
     LOCAL_CFLAGS += -DFEATURE_WIDE_COLOR

--- a/sdm/libs/hwc2/hwc_buffer_allocator.h
+++ b/sdm/libs/hwc2/hwc_buffer_allocator.h
@@ -26,6 +26,9 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#ifdef USE_GRALLOC1
+#include "hwc_buffer_allocator1.h"
+#else
 #ifndef __HWC_BUFFER_ALLOCATOR_H__
 #define __HWC_BUFFER_ALLOCATOR_H__
 
@@ -71,3 +74,4 @@ class HWCBufferAllocator : public BufferAllocator {
 
 }  // namespace sdm
 #endif  // __HWC_BUFFER_ALLOCATOR_H__
+#endif // USE_GRALLOC1

--- a/sdm/libs/hwc2/hwc_buffer_allocator1.cpp
+++ b/sdm/libs/hwc2/hwc_buffer_allocator1.cpp
@@ -1,0 +1,409 @@
+/*
+* Copyright (c) 2015-2017, The Linux Foundation. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are
+* met:
+*  * Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above
+*    copyright notice, this list of conditions and the following
+*    disclaimer in the documentation and/or other materials provided
+*    with the distribution.
+*  * Neither the name of The Linux Foundation nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+* OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+* IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <gralloc_priv.h>
+
+#include <core/buffer_allocator.h>
+#include <utils/constants.h>
+#include <utils/debug.h>
+
+#include "hwc_buffer_allocator.h"
+#include "hwc_debugger.h"
+#include "gr_utils.h"
+
+#define __CLASS__ "HWCBufferAllocator"
+
+namespace sdm {
+
+DisplayError HWCBufferAllocator::Init() {
+  int err = hw_get_module(GRALLOC_HARDWARE_MODULE_ID, &module_);
+  if (err != 0) {
+    DLOGE("FATAL: can not get GRALLOC module");
+    return kErrorResources;
+  }
+
+  err = gralloc1_open(module_, &gralloc_device_);
+  if (err != 0) {
+    DLOGE("FATAL: can not open GRALLOC device");
+    return kErrorResources;
+  }
+
+  if (gralloc_device_ == nullptr) {
+    DLOGE("FATAL: gralloc device is null");
+    return kErrorResources;
+  }
+
+  ReleaseBuffer_ = reinterpret_cast<GRALLOC1_PFN_RELEASE>(
+      gralloc_device_->getFunction(gralloc_device_, GRALLOC1_FUNCTION_RELEASE));
+  Perform_ = reinterpret_cast<GRALLOC1_PFN_PERFORM>(
+      gralloc_device_->getFunction(gralloc_device_, GRALLOC1_FUNCTION_PERFORM));
+  Lock_ = reinterpret_cast<GRALLOC1_PFN_LOCK>(
+      gralloc_device_->getFunction(gralloc_device_, GRALLOC1_FUNCTION_LOCK));
+  Unlock_ = reinterpret_cast<GRALLOC1_PFN_UNLOCK>(
+      gralloc_device_->getFunction(gralloc_device_, GRALLOC1_FUNCTION_UNLOCK));
+
+  return kErrorNone;
+}
+
+DisplayError HWCBufferAllocator::Deinit() {
+  if (gralloc_device_ != nullptr) {
+    int err = gralloc1_close(gralloc_device_);
+    if (err != 0) {
+      DLOGE("FATAL: can not close GRALLOC device");
+      return kErrorResources;
+    }
+  }
+  return kErrorNone;
+}
+
+DisplayError HWCBufferAllocator::AllocateBuffer(BufferInfo *buffer_info) {
+  const BufferConfig &buffer_config = buffer_info->buffer_config;
+  AllocatedBufferInfo *alloc_buffer_info = &buffer_info->alloc_buffer_info;
+  uint32_t width = buffer_config.width;
+  uint32_t height = buffer_config.height;
+  int format;
+  uint64_t alloc_flags = 0;
+  int error = SetBufferInfo(buffer_config.format, &format, &alloc_flags);
+  if (error != 0) {
+    return kErrorParameters;
+  }
+
+  if (buffer_config.secure) {
+    alloc_flags |= GRALLOC1_PRODUCER_USAGE_PROTECTED;
+  }
+
+  if (buffer_config.secure_camera) {
+    alloc_flags |= GRALLOC1_PRODUCER_USAGE_CAMERA;
+  }
+
+  if (!buffer_config.cache) {
+    // Allocate uncached buffers
+    alloc_flags |= GRALLOC_USAGE_PRIVATE_UNCACHED;
+  }
+
+  if (buffer_config.gfx_client) {
+    alloc_flags |= GRALLOC1_CONSUMER_USAGE_GPU_TEXTURE;
+  }
+
+  uint64_t producer_usage = alloc_flags;
+  uint64_t consumer_usage = (alloc_flags | GRALLOC1_CONSUMER_USAGE_HWCOMPOSER);
+  // CreateBuffer
+  private_handle_t *hnd = nullptr;
+  Perform_(gralloc_device_, GRALLOC1_MODULE_PERFORM_ALLOCATE_BUFFER, width, height, format,
+           producer_usage, consumer_usage, &hnd);
+
+  if (hnd) {
+    alloc_buffer_info->fd = hnd->fd;
+    alloc_buffer_info->stride = UINT32(hnd->width);
+    alloc_buffer_info->aligned_width = UINT32(hnd->width);
+    alloc_buffer_info->aligned_height = UINT32(hnd->height);
+    alloc_buffer_info->size = hnd->size;
+  } else {
+    DLOGE("Failed to allocate memory");
+    return kErrorMemory;
+  }
+
+  buffer_info->private_data = reinterpret_cast<void *>(hnd);
+  return kErrorNone;
+}
+
+DisplayError HWCBufferAllocator::FreeBuffer(BufferInfo *buffer_info) {
+  DisplayError err = kErrorNone;
+  buffer_handle_t hnd = static_cast<private_handle_t *>(buffer_info->private_data);
+  ReleaseBuffer_(gralloc_device_, hnd);
+  AllocatedBufferInfo *alloc_buffer_info = &buffer_info->alloc_buffer_info;
+
+  alloc_buffer_info->fd = -1;
+  alloc_buffer_info->stride = 0;
+  alloc_buffer_info->size = 0;
+  buffer_info->private_data = NULL;
+  return err;
+}
+
+void HWCBufferAllocator::GetCustomWidthAndHeight(const private_handle_t *handle, int *width,
+                                                 int *height) {
+  Perform_(gralloc_device_, GRALLOC_MODULE_PERFORM_GET_CUSTOM_STRIDE_AND_HEIGHT_FROM_HANDLE, handle,
+           width, height);
+}
+
+void HWCBufferAllocator::GetAlignedWidthAndHeight(int width, int height, int format,
+                                                  uint32_t alloc_type, int *aligned_width,
+                                                  int *aligned_height) {
+  int tile_enabled;
+  gralloc1_producer_usage_t producer_usage = GRALLOC1_PRODUCER_USAGE_NONE;
+  gralloc1_consumer_usage_t consumer_usage = GRALLOC1_CONSUMER_USAGE_NONE;
+  if (alloc_type & GRALLOC_USAGE_HW_FB) {
+    consumer_usage = GRALLOC1_CONSUMER_USAGE_CLIENT_TARGET;
+  }
+  if (alloc_type & GRALLOC_USAGE_PRIVATE_ALLOC_UBWC) {
+    producer_usage = GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
+  }
+
+  Perform_(gralloc_device_, GRALLOC_MODULE_PERFORM_GET_ATTRIBUTES, width, height, format,
+           producer_usage, consumer_usage, aligned_width, aligned_height, &tile_enabled);
+}
+
+uint32_t HWCBufferAllocator::GetBufferSize(BufferInfo *buffer_info) {
+  const BufferConfig &buffer_config = buffer_info->buffer_config;
+  uint64_t alloc_flags = GRALLOC_USAGE_PRIVATE_IOMMU_HEAP;
+
+  int width = INT(buffer_config.width);
+  int height = INT(buffer_config.height);
+  int format;
+
+  if (buffer_config.secure) {
+    alloc_flags |= INT(GRALLOC_USAGE_PROTECTED);
+  }
+
+  if (!buffer_config.cache) {
+    // Allocate uncached buffers
+    alloc_flags |= GRALLOC_USAGE_PRIVATE_UNCACHED;
+  }
+
+  if (SetBufferInfo(buffer_config.format, &format, &alloc_flags) < 0) {
+    return 0;
+  }
+
+  uint32_t aligned_width = 0, aligned_height = 0, buffer_size = 0;
+  gralloc1_producer_usage_t producer_usage = GRALLOC1_PRODUCER_USAGE_NONE;
+  gralloc1_consumer_usage_t consumer_usage = GRALLOC1_CONSUMER_USAGE_NONE;
+  // TODO(user): Currently both flags are treated similarly in gralloc
+  producer_usage = gralloc1_producer_usage_t(alloc_flags);
+  consumer_usage = gralloc1_consumer_usage_t(alloc_flags);
+  gralloc1::BufferInfo info(width, height, format, producer_usage, consumer_usage);
+  GetBufferSizeAndDimensions(info, &buffer_size, &aligned_width, &aligned_height);
+  return buffer_size;
+}
+
+int HWCBufferAllocator::SetBufferInfo(LayerBufferFormat format, int *target, uint64_t *flags) {
+  switch (format) {
+    case kFormatRGBA8888:
+      *target = HAL_PIXEL_FORMAT_RGBA_8888;
+      break;
+    case kFormatRGBX8888:
+      *target = HAL_PIXEL_FORMAT_RGBX_8888;
+      break;
+    case kFormatRGB888:
+      *target = HAL_PIXEL_FORMAT_RGB_888;
+      break;
+    case kFormatRGB565:
+      *target = HAL_PIXEL_FORMAT_RGB_565;
+      break;
+    case kFormatBGR565:
+      *target = HAL_PIXEL_FORMAT_BGR_565;
+      break;
+    case kFormatBGR888:
+      *target = HAL_PIXEL_FORMAT_BGR_888;
+      break;
+    case kFormatBGRA8888:
+      *target = HAL_PIXEL_FORMAT_BGRA_8888;
+      break;
+    case kFormatYCrCb420PlanarStride16:
+      *target = HAL_PIXEL_FORMAT_YV12;
+      break;
+    case kFormatYCrCb420SemiPlanar:
+      *target = HAL_PIXEL_FORMAT_YCrCb_420_SP;
+      break;
+    case kFormatYCbCr420SemiPlanar:
+      *target = HAL_PIXEL_FORMAT_YCbCr_420_SP;
+      break;
+    case kFormatYCbCr422H2V1Packed:
+      *target = HAL_PIXEL_FORMAT_YCbCr_422_I;
+      break;
+    case kFormatCbYCrY422H2V1Packed:
+      *target = HAL_PIXEL_FORMAT_CbYCrY_422_I;
+      break;
+    case kFormatYCbCr422H2V1SemiPlanar:
+      *target = HAL_PIXEL_FORMAT_YCbCr_422_SP;
+      break;
+    case kFormatYCbCr420SemiPlanarVenus:
+      *target = HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS;
+      break;
+    case kFormatYCrCb420SemiPlanarVenus:
+      *target = HAL_PIXEL_FORMAT_YCrCb_420_SP_VENUS;
+      break;
+    case kFormatYCbCr420SPVenusUbwc:
+      *target = HAL_PIXEL_FORMAT_YCbCr_420_SP_VENUS_UBWC;
+      *flags |= GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
+      break;
+    case kFormatRGBA5551:
+      *target = HAL_PIXEL_FORMAT_RGBA_5551;
+      break;
+    case kFormatRGBA4444:
+      *target = HAL_PIXEL_FORMAT_RGBA_4444;
+      break;
+    case kFormatRGBA1010102:
+      *target = HAL_PIXEL_FORMAT_RGBA_1010102;
+      break;
+    case kFormatARGB2101010:
+      *target = HAL_PIXEL_FORMAT_ARGB_2101010;
+      break;
+    case kFormatRGBX1010102:
+      *target = HAL_PIXEL_FORMAT_RGBX_1010102;
+      break;
+    case kFormatXRGB2101010:
+      *target = HAL_PIXEL_FORMAT_XRGB_2101010;
+      break;
+    case kFormatBGRA1010102:
+      *target = HAL_PIXEL_FORMAT_BGRA_1010102;
+      break;
+    case kFormatABGR2101010:
+      *target = HAL_PIXEL_FORMAT_ABGR_2101010;
+      break;
+    case kFormatBGRX1010102:
+      *target = HAL_PIXEL_FORMAT_BGRX_1010102;
+      break;
+    case kFormatXBGR2101010:
+      *target = HAL_PIXEL_FORMAT_XBGR_2101010;
+      break;
+    case kFormatYCbCr420P010:
+      *target = HAL_PIXEL_FORMAT_YCbCr_420_P010;
+      break;
+    case kFormatYCbCr420TP10Ubwc:
+      *target = HAL_PIXEL_FORMAT_YCbCr_420_TP10_UBWC;
+      *flags |= GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
+      break;
+    case kFormatYCbCr420P010Ubwc:
+      *target = HAL_PIXEL_FORMAT_YCbCr_420_P010_UBWC;
+      *flags |= GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
+      break;
+    case kFormatRGBA8888Ubwc:
+      *target = HAL_PIXEL_FORMAT_RGBA_8888;
+      *flags |= GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
+      break;
+    case kFormatRGBX8888Ubwc:
+      *target = HAL_PIXEL_FORMAT_RGBX_8888;
+      *flags |= GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
+      break;
+    case kFormatBGR565Ubwc:
+      *target = HAL_PIXEL_FORMAT_BGR_565;
+      *flags |= GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
+      break;
+    case kFormatRGBA1010102Ubwc:
+      *target = HAL_PIXEL_FORMAT_RGBA_1010102;
+      *flags |= GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
+      break;
+    case kFormatRGBX1010102Ubwc:
+      *target = HAL_PIXEL_FORMAT_RGBX_1010102;
+      *flags |= GRALLOC_USAGE_PRIVATE_ALLOC_UBWC;
+      break;
+    default:
+      DLOGE("Unsupported format = 0x%x", format);
+      return -EINVAL;
+  }
+  return 0;
+}
+
+DisplayError HWCBufferAllocator::GetAllocatedBufferInfo(
+    const BufferConfig &buffer_config, AllocatedBufferInfo *allocated_buffer_info) {
+  // TODO(user): This API should pass the buffer_info of the already allocated buffer
+  // The private_data can then be typecast to the private_handle and used directly.
+  uint64_t alloc_flags = GRALLOC_USAGE_PRIVATE_IOMMU_HEAP;
+
+  int width = INT(buffer_config.width);
+  int height = INT(buffer_config.height);
+  int format;
+
+  if (buffer_config.secure) {
+    alloc_flags |= INT(GRALLOC_USAGE_PROTECTED);
+  }
+
+  if (!buffer_config.cache) {
+    // Allocate uncached buffers
+    alloc_flags |= GRALLOC_USAGE_PRIVATE_UNCACHED;
+  }
+
+  if (SetBufferInfo(buffer_config.format, &format, &alloc_flags) < 0) {
+    return kErrorParameters;
+  }
+
+  uint32_t aligned_width = 0, aligned_height = 0, buffer_size = 0;
+  gralloc1_producer_usage_t producer_usage = GRALLOC1_PRODUCER_USAGE_NONE;
+  gralloc1_consumer_usage_t consumer_usage = GRALLOC1_CONSUMER_USAGE_NONE;
+  // TODO(user): Currently both flags are treated similarly in gralloc
+  producer_usage = gralloc1_producer_usage_t(alloc_flags);
+  consumer_usage = gralloc1_consumer_usage_t(alloc_flags);
+  gralloc1::BufferInfo info(width, height, format, producer_usage, consumer_usage);
+  GetBufferSizeAndDimensions(info, &buffer_size, &aligned_width, &aligned_height);
+  allocated_buffer_info->stride = UINT32(aligned_width);
+  allocated_buffer_info->aligned_width = UINT32(aligned_width);
+  allocated_buffer_info->aligned_height = UINT32(aligned_height);
+  allocated_buffer_info->size = UINT32(buffer_size);
+
+  return kErrorNone;
+}
+
+DisplayError HWCBufferAllocator::GetBufferLayout(const AllocatedBufferInfo &buf_info,
+                                                 uint32_t stride[4], uint32_t offset[4],
+                                                 uint32_t *num_planes) {
+  // TODO(user): Transition APIs to not need a private handle
+  private_handle_t hnd(-1, 0, 0, 0, 0, 0, 0);
+  int format = HAL_PIXEL_FORMAT_RGBA_8888;
+  uint64_t flags = 0;
+
+  SetBufferInfo(buf_info.format, &format, &flags);
+  // Setup only the required stuff, skip rest
+  hnd.format = format;
+  hnd.width = INT32(buf_info.aligned_width);
+  hnd.height = INT32(buf_info.aligned_height);
+  if (flags & GRALLOC_USAGE_PRIVATE_ALLOC_UBWC) {
+    hnd.flags = private_handle_t::PRIV_FLAGS_UBWC_ALIGNED;
+  }
+
+  int ret = gralloc1::GetBufferLayout(&hnd, stride, offset, num_planes);
+  if (ret < 0) {
+    DLOGE("GetBufferLayout failed");
+    return kErrorParameters;
+  }
+
+  return kErrorNone;
+}
+
+DisplayError HWCBufferAllocator::MapBuffer(const private_handle_t *handle, int acquire_fence) {
+  void* buffer_ptr = NULL;
+  const gralloc1_rect_t accessRegion = {
+        .left = 0,
+        .top = 0,
+        .width = 0,
+        .height = 0
+  };
+  Lock_(gralloc_device_, handle, GRALLOC1_PRODUCER_USAGE_CPU_READ, GRALLOC1_CONSUMER_USAGE_NONE,
+        &accessRegion, &buffer_ptr, acquire_fence);
+  if (!buffer_ptr) {
+    return kErrorUndefined;
+  }
+
+  return kErrorNone;
+}
+
+DisplayError HWCBufferAllocator::UnmapBuffer(const private_handle_t *handle, int* release_fence) {
+  return (DisplayError)(Unlock_(gralloc_device_, handle, release_fence));
+}
+
+}  // namespace sdm

--- a/sdm/libs/hwc2/hwc_buffer_allocator1.h
+++ b/sdm/libs/hwc2/hwc_buffer_allocator1.h
@@ -1,0 +1,75 @@
+/*
+* Copyright (c) 2015-2017, The Linux Foundation. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are
+* met:
+*  * Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*  * Redistributions in binary form must reproduce the above
+*    copyright notice, this list of conditions and the following
+*    disclaimer in the documentation and/or other materials provided
+*    with the distribution.
+*  * Neither the name of The Linux Foundation nor the names of its
+*    contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+* WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+* BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+* OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+* IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef __HWC_BUFFER_ALLOCATOR_H__
+#define __HWC_BUFFER_ALLOCATOR_H__
+
+#include <fcntl.h>
+#include <sys/mman.h>
+
+#include <hardware/gralloc1.h>
+#include "gralloc_priv.h"
+
+namespace sdm {
+
+template <class Type>
+inline Type ALIGN(Type x, Type align) {
+  return (x + align - 1) & ~(align - 1);
+}
+
+class HWCBufferAllocator : public BufferAllocator {
+ public:
+  DisplayError Init();
+  DisplayError Deinit();
+  DisplayError AllocateBuffer(BufferInfo *buffer_info);
+  DisplayError FreeBuffer(BufferInfo *buffer_info);
+  uint32_t GetBufferSize(BufferInfo *buffer_info);
+
+  void GetCustomWidthAndHeight(const private_handle_t *handle, int *width, int *height);
+  void GetAlignedWidthAndHeight(int width, int height, int format, uint32_t alloc_type,
+                                int *aligned_width, int *aligned_height);
+  DisplayError GetAllocatedBufferInfo(const BufferConfig &buffer_config,
+                                      AllocatedBufferInfo *allocated_buffer_info);
+  DisplayError GetBufferLayout(const AllocatedBufferInfo &buf_info,
+                               uint32_t stride[4], uint32_t offset[4],
+                               uint32_t *num_planes);
+  int SetBufferInfo(LayerBufferFormat format, int *target, uint64_t *flags);
+  DisplayError MapBuffer(const private_handle_t *handle, int acquire_fence);
+  DisplayError UnmapBuffer(const private_handle_t *handle, int* release_fence);
+
+ private:
+  gralloc1_device_t *gralloc_device_ = nullptr;
+  const hw_module_t *module_;
+  GRALLOC1_PFN_RELEASE ReleaseBuffer_ = nullptr;
+  GRALLOC1_PFN_PERFORM Perform_ = nullptr;
+  GRALLOC1_PFN_LOCK Lock_ = nullptr;
+  GRALLOC1_PFN_UNLOCK Unlock_ = nullptr;
+};
+
+}  // namespace sdm
+#endif  // __HWC_BUFFER_ALLOCATOR_H__

--- a/sdm/libs/hwc2/hwc_session.cpp
+++ b/sdm/libs/hwc2/hwc_session.cpp
@@ -161,6 +161,15 @@ int HWCSession::Init() {
 
   g_hwc_uevent_.Register(this);
 
+#ifdef USE_GRALLOC1
+  DisplayError grerr = buffer_allocator_.Init();
+  if (grerr != kErrorNone) {
+    ALOGE("%s::%s: Buffer allocaor initialization failed. Error = %d",
+          __CLASS__, __FUNCTION__, grerr);
+    return -EINVAL;
+  }
+#endif
+
   auto error = CoreInterface::CreateCore(&buffer_allocator_, &buffer_sync_handler_,
                                     &socket_handler_, &core_intf_);
   if (error != kErrorNone) {
@@ -204,6 +213,10 @@ int HWCSession::Deinit() {
 
   g_hwc_uevent_.Register(nullptr);
   CoreInterface::DestroyCore();
+
+#ifdef USE_GRALLOC1
+    buffer_allocator_.Deinit();
+#endif
 
   return 0;
 }


### PR DESCRIPTION
The new-era gralloc is a variant of gralloc1, but it happens to
have major incompatibilities with devices using older Adreno
libraries, producing artifacts and huge memory leaks.
Re-introduce gralloc1 to get the legacy devices working again.

Targets requiring gralloc1 will continue needing the flag
TARGET_USES_GRALLOC1 set to true.

Tested on SoMC Nile Discovery DSDS on k4.9, Android 9.0, SDE.