### PR TITLE
allocators: Switch gralloc include based on TARGET_USES_GRALLOC1.

### DIFF
--- a/include/Android.mk
+++ b/include/Android.mk
@@ -19,8 +19,12 @@ LOCAL_EXPORT_C_INCLUDE_DIRS   := $(LOCAL_PATH) \
                                  $(display_top)/libqdutils \
                                  $(display_top)/libqservice \
                                  $(display_top)/gpu_tonemapper \
-                                 $(display_top)/sdm/include \
-                                 $(display_top)/gralloc \
-                                 $(display_top)/libgralloc1
+                                 $(display_top)/sdm/include
+
+ifeq ($(TARGET_USES_GRALLOC1),true)
+LOCAL_EXPORT_C_INCLUDE_DIRS += $(display_top)/gralloc1
+else
+LOCAL_EXPORT_C_INCLUDE_DIRS += $(display_top)/gralloc
+endif
 
 include $(BUILD_HEADER_LIBRARY)


### PR DESCRIPTION
The original include directory for gralloc1 was renamed from libgralloc1
to gralloc1 when migrating from 6.3 to 7.3. Furthermore, both allocators
include files with the same name, hindering the listing of both folders
at the same time.