### PR TITLE
sdm: core: fb: add basic detection of the primary display

### DIFF
--- a/sdm/libs/core/fb/hw_info.cpp
+++ b/sdm/libs/core/fb/hw_info.cpp
@@ -557,8 +557,24 @@ DisplayError HWInfo::GetFirstDisplayInterfaceType(HWDisplayInterfaceInfo *hw_dis
 }
 
 DisplayError HWInfo::GetDisplaysStatus(HWDisplaysInfo *hw_displays_info) {
-  // TODO(user):
-  DLOGW("This operation is not supported on FB Driver.");
+  if (!hw_displays_info) {
+    DLOGE("No output parameter provided!");
+    return kErrorParameters;
+  }
+  hw_displays_info->clear();
+
+  HWDisplayInterfaceInfo hw_disp_info = {};
+  DisplayError ret = HWInfo::GetFirstDisplayInterfaceType(&hw_disp_info);
+  if (ret != kErrorNone) {
+    return ret;
+  }
+
+  HWDisplayInfo hw_info = {};
+  hw_info.display_id = 0;
+  hw_info.display_type = hw_disp_info.type;
+  hw_info.is_connected = hw_disp_info.is_connected;
+  hw_info.is_primary = hw_info.display_type == kPrimary;
+  (*hw_displays_info)[hw_info.display_id] = hw_info;
   return kErrorNone;
 }
 


### PR DESCRIPTION
While introducing support for multiple displays, detection of fb displays was practically rendered nonfunctional.
According to the log message, FB misses support for the added operation (GetDisplaysStatus).
Work around that by calling the previously used function (GetFirstDisplayInterfaceType).
That function populates a HWDisplayInterfaceInfo struct, which can be used to populate a valid HWDisplaysInfo struct.