### PR TITLE
sdm: core: add property to skip creating extension interface

### DIFF
--- a/include/display_properties.h
+++ b/include/display_properties.h
@@ -100,4 +100,6 @@
 #define ZERO_SWAP_INTERVAL                   "vendor.debug.egl.swapinterval"
 #define WINDOW_RECT_PROP                     DISPLAY_PROP("window_rect")
 
+#define SKIP_EXTENSION_INTF                  DISPLAY_PROP("skip_extension_intf")
+
 #endif  // __DISPLAY_PROPERTIES_H__

--- a/sdm/libs/core/core_impl.cpp
+++ b/sdm/libs/core/core_impl.cpp
@@ -49,9 +49,14 @@ CoreImpl::CoreImpl(BufferAllocator *buffer_allocator,
 DisplayError CoreImpl::Init() {
   SCOPE_LOCK(locker_);
   DisplayError error = kErrorNone;
+  bool skip_extension_intf = false;
+  int value = 0;
+  if (Debug::GetProperty(SKIP_EXTENSION_INTF, &value) == kErrorNone) {
+    skip_extension_intf = (value == 1);
+  }
 
   // Try to load extension library & get handle to its interface.
-  if (extension_lib_.Open(EXTENSION_LIBRARY_NAME)) {
+  if (!skip_extension_intf && extension_lib_.Open(EXTENSION_LIBRARY_NAME)) {
     if (!extension_lib_.Sym(CREATE_EXTENSION_INTERFACE_NAME,
                             reinterpret_cast<void **>(&create_extension_intf_)) ||
         !extension_lib_.Sym(DESTROY_EXTENSION_INTERFACE_NAME,


### PR DESCRIPTION
For some platforms, the extension interface requires libraries that are not provided, like libscalar.so
To work around the issue, simply skip loading the extension library and the interface creation.
This does mean losing the possibility to have SDE composition, but the platforms that need this never used it previously, so it is not a critical loss.