### PR TITLE
[WIP/DONOTMERGE] [Q-COMPAT] Fix Q compiler warnings

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -9,6 +9,7 @@ display_config_version := $(shell \
 #Common C flags
 common_flags := -Wno-missing-field-initializers
 common_flags += -Wconversion -Wall -Werror -std=c++14
+common_flags += -fPIC
 
 ifeq ($(TARGET_USES_GRALLOC1), true)
 common_flags += -DUSE_GRALLOC1

--- a/libqdutils/Android.mk
+++ b/libqdutils/Android.mk
@@ -21,7 +21,7 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 
 LOCAL_COPY_HEADERS_TO           := $(common_header_export_path)
-LOCAL_COPY_HEADERS              := qdMetaData.h qd_utils.h
+LOCAL_COPY_HEADERS              := qdMetaData.h
 LOCAL_SHARED_LIBRARIES          := liblog libcutils
 LOCAL_C_INCLUDES                := $(common_includes)
 LOCAL_HEADER_LIBRARIES          := display_headers

--- a/sdm/libs/hwc2/hwc_display.cpp
+++ b/sdm/libs/hwc2/hwc_display.cpp
@@ -1788,11 +1788,15 @@ int HWCDisplay::SetDisplayStatus(DisplayStatus display_status) {
   switch (display_status) {
     case kDisplayStatusResume:
       display_paused_ = false;
+      status = INT32(SetPowerMode(HWC2::PowerMode::On));
+      break;
     case kDisplayStatusOnline:
       status = INT32(SetPowerMode(HWC2::PowerMode::On));
       break;
     case kDisplayStatusPause:
       display_paused_ = true;
+      status = INT32(SetPowerMode(HWC2::PowerMode::Off));
+      break;
     case kDisplayStatusOffline:
       status = INT32(SetPowerMode(HWC2::PowerMode::Off));
       break;


### PR DESCRIPTION
Not sure about the `-Wnoimplicit-fallthrough` one, are the `break` statements better or just leave the compiler option?