### PR TITLE
[DONOTMERGE] libqdutils: Don't copy qd_utils.h header twice.

### DIFF
--- a/libqdutils/Android.mk
+++ b/libqdutils/Android.mk
@@ -1,5 +1,12 @@
 LOCAL_PATH := $(call my-dir)
 include $(LOCAL_PATH)/../common.mk
+
+include $(CLEAR_VARS)
+LOCAL_VENDOR_MODULE           := true
+LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)
+LOCAL_COPY_HEADERS            := qd_utils.h
+include $(BUILD_COPY_HEADERS)
+
 include $(CLEAR_VARS)
 
 LOCAL_MODULE                  := libqdutils
@@ -13,7 +20,7 @@ LOCAL_HEADER_LIBRARIES        += libutils_headers
 LOCAL_CFLAGS                  := $(common_flags) -DLOG_TAG=\"qdutils\" -Wno-sign-conversion
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps)
 LOCAL_COPY_HEADERS_TO         := $(common_header_export_path)
-LOCAL_COPY_HEADERS            := display_config.h qd_utils.h
+LOCAL_COPY_HEADERS            := display_config.h
 LOCAL_SRC_FILES               := qd_utils.cpp \
                                  display_config.cpp
 include $(BUILD_SHARED_LIBRARY)
@@ -21,7 +28,7 @@ include $(BUILD_SHARED_LIBRARY)
 include $(CLEAR_VARS)
 
 LOCAL_COPY_HEADERS_TO           := $(common_header_export_path)
-LOCAL_COPY_HEADERS              := qdMetaData.h qd_utils.h
+LOCAL_COPY_HEADERS              := qdMetaData.h
 LOCAL_SHARED_LIBRARIES          := liblog libcutils
 LOCAL_C_INCLUDES                := $(common_includes)
 LOCAL_HEADER_LIBRARIES          := display_headers

--- a/sdm/libs/hwc2/Android.mk
+++ b/sdm/libs/hwc2/Android.mk
@@ -12,6 +12,7 @@ LOCAL_C_INCLUDES              := $(common_includes)
 LOCAL_HEADER_LIBRARIES        := display_headers
 
 LOCAL_CFLAGS                  := -Wno-missing-field-initializers -Wno-unused-parameter \
+                                 -Wno-error=implicit-fallthrough \
                                  -std=c++11 -fcolor-diagnostics\
                                  -DLOG_TAG=\"SDM\" $(common_flags)
 LOCAL_CLANG                   := true


### PR DESCRIPTION
This causes a hard error on Android 10 because two targets provide the same filename (ultimately being the same file...).

### Donotmerge, because:
Please let me know if you rather have this a _module_ where `libqdutils` and ` libqdMetaData` depend on.