### PR TITLE
[DISPLAY] [7.1.r1] Revert "gralloc: 64-bytes row alignment for RAW10 buffers"

### DIFF
--- a/gralloc/gr_utils.cpp
+++ b/gralloc/gr_utils.cpp
@@ -905,13 +905,7 @@ void GetAlignedWidthAndHeight(const BufferInfo &info, unsigned int *alignedw,
       aligned_w = ALIGN(width * 12 / 8, 16);
       break;
     case HAL_PIXEL_FORMAT_RAW10:
-      {
-        const unsigned int gpu_alignment =
-            AdrenoMemInfo::GetInstance()->GetGpuPixelAlignment();
-        // gpu_alignment can return 1. Make sure it's at least 64.
-        const unsigned int raw10_alignment = std::max(gpu_alignment, 64u);
-        aligned_w = ALIGN(width * 10 / 8, raw10_alignment);
-      }
+      aligned_w = ALIGN(width * 10 / 8, 16);
       break;
     case HAL_PIXEL_FORMAT_RAW8:
       aligned_w = ALIGN(width, 16);


### PR DESCRIPTION
See #30

This change is specific to pixel devices and does not apply on other hardware.

This reverts commit ea800cd6c5f54c1ba19a48a9e8df60eae369f09e.
