### PR TITLE
[Q/R] hwc2: Provide dummy SetDisplayBrightness function to satisfy AOSP

### DIFF
--- a/sdm/libs/hwc2/hwc_session.cpp
+++ b/sdm/libs/hwc2/hwc_session.cpp
@@ -1146,6 +1146,11 @@ int32_t HWCSession::ValidateDisplay(hwc2_device_t *device, hwc2_display_t displa
   return INT32(status);
 }
 
+int32_t HWCSession::SetDisplayBrightness(hwc2_device_t *device, hwc2_display_t display,
+                                         float brightness) {
+  return HWC2_ERROR_UNSUPPORTED;
+}
+
 hwc2_function_pointer_t HWCSession::GetFunction(struct hwc2_device *device,
                                                 int32_t int_descriptor) {
   auto descriptor = static_cast<HWC2::FunctionDescriptor>(int_descriptor);
@@ -1261,6 +1266,8 @@ hwc2_function_pointer_t HWCSession::GetFunction(struct hwc2_device *device,
       return AsFP<HWC2_PFN_GET_DISPLAY_CAPABILITIES>(HWCSession::GetDisplayCapabilities);
     case HWC2::FunctionDescriptor::GetDisplayBrightnessSupport:
       return AsFP<HWC2_PFN_GET_DISPLAY_BRIGHTNESS_SUPPORT>(HWCSession::GetDisplayBrightnessSupport);
+    case HWC2::FunctionDescriptor::SetDisplayBrightness:
+      return AsFP<HWC2_PFN_SET_DISPLAY_BRIGHTNESS>(HWCSession::SetDisplayBrightness);
     default:
       DLOGD("Unknown/Unimplemented function descriptor: %d (%s)", int_descriptor,
             to_string(descriptor).c_str());

--- a/sdm/libs/hwc2/hwc_session.h
+++ b/sdm/libs/hwc2/hwc_session.h
@@ -208,6 +208,9 @@ class HWCSession : hwc2_device_t, HWCUEventListener, IDisplayConfig, public qCli
                                         uint32_t *outNumCapabilities, uint32_t *outCapabilities);
   static int32_t GetDisplayBrightnessSupport(hwc2_device_t *device, hwc2_display_t display,
                                              bool *outSupport);
+  static int32_t SetDisplayBrightness(hwc2_device_t *device, hwc2_display_t display,
+                                      float brightness);
+
 
   // HWCDisplayEventHandler
   virtual void DisplayPowerReset();


### PR DESCRIPTION
AOSP decided to outright [ignore] the brightness display capability they
rightfully introduced a check for in [the commit before]. Without this
check brightness through HWC2 is [still optional] but initialization
fails when the function is not available:

    I SDM     : HWCSession::CreatePrimaryDisplay: Primary display created.
    I SDM     : HWCColorManager::CreateColorManager: Successfully loaded libsdm-disp-vndapis.so
    D SDM     : HWCSession::GetFunction: Unknown/Unimplemented function descriptor: 44 (SetLayerFloatColor)
    D SDM     : HWCSession::GetFunction: Unknown/Unimplemented function descriptor: 61 (SetDisplayBrightness)
    E android.hardware.graphics.composer@2.3-service: failed to get hwcomposer2 function 61
    I SDM     : HWCSession::DestroyNonPluggableDisplay: Destroy display 28-0, client id = 0

We have three options:
- Revert the breaking commit (or alter it to require just
  getDisplayCapabilities, and make setDisplayBrightness mandatory iff
  the BRIGHTNESS capability is reported _and getDisplayBrightnessSupport
  agrees);
- Pick AOSP changes to the CAF HAL and deprecate brightness support from
  our lights HAL;
- Introduce an empty and unused SetDisplayBrightness function and call
  it a day.

It is worthless to cherrypick the numerous brightness changes to our CAF
HAL - none are properly compatible, so we're likely better off waiting
for CAF to drop Android-11 compatible tags and switch over "seamlessly".

[ignore]: https://android.googlesource.com/platform/hardware/interfaces/+/2be3570bc91f3d2661f3603dc1288cb2a9cea9ef
[the commit before]: https://android.googlesource.com/platform/hardware/interfaces/+/0686afa15a0c2f3666246977ebd1db37e640ebad
[still optional]: https://android.googlesource.com/platform/hardware/interfaces/+/3e83c4558a60af8938d9e2e3955a4b87faeb0c9d

---

Tested on Akatsuki DSDS running Android 10 and Griffin DSDS running Android 11.