### PR TITLE
[8.1] Libhidltransport removal from Android.mk

### DIFF
--- a/gralloc/Android.mk
+++ b/gralloc/Android.mk
@@ -65,7 +65,6 @@ LOCAL_C_INCLUDES              := $(kernel_includes)
 LOCAL_HEADER_LIBRARIES        := display_headers
 LOCAL_SHARED_LIBRARIES        := $(common_libs) \
                                   libhidlbase \
-                                  libhidltransport \
                                   libqdMetaData \
                                   libgrallocutils \
                                   libgralloccore \
@@ -90,7 +89,6 @@ LOCAL_MODULE_TAGS             := optional
 LOCAL_HEADER_LIBRARIES        := display_headers
 LOCAL_SHARED_LIBRARIES        := $(common_libs) \
                                  libhidlbase \
-                                 libhidltransport\
                                  libqdMetaData \
                                  libgrallocutils \
                                  libgralloccore \

--- a/sdm/libs/hwc2/Android.mk
+++ b/sdm/libs/hwc2/Android.mk
@@ -20,7 +20,7 @@ LOCAL_CLANG                   := true
 LOCAL_SHARED_LIBRARIES        := libsdmcore libqservice libbinder libhardware libhardware_legacy \
                                  libutils libcutils libsync libqdutils libqdMetaData \
                                  libdisplaydebug libsdmutils libc++ liblog libgrallocutils libui \
-                                 libgpu_tonemapper libhidlbase libhidltransport \
+                                 libgpu_tonemapper libhidlbase \
                                  android.hardware.graphics.mapper@2.0 \
                                  android.hardware.graphics.mapper@2.1 \
                                  android.hardware.graphics.mapper@3.0 \


### PR DESCRIPTION
This change was made because android Q deprecated this library. 
All the symbols this library provided are in libhidlbase.
Thus remove this library.