### PR TITLE
[LA.UM.8.1.r1] Disable TARGET_BOARD_AUTO

### DIFF
--- a/sdm/libs/hwc2/Android.mk
+++ b/sdm/libs/hwc2/Android.mk
@@ -39,10 +39,6 @@ LOCAL_SHARED_LIBRARIES        := libsdmcore libqservice libbinder libhardware li
                                  vendor.display.config@1.9 \
                                  vendor.display.config@1.10
 
-ifeq ($(TARGET_BOARD_AUTO), true)
-LOCAL_CFLAGS                  += -DCONFIG_BASEID_FROM_PROP
-endif
-
 LOCAL_SRC_FILES               := hwc_session.cpp \
                                  hwc_session_services.cpp \
                                  hwc_display.cpp \


### PR DESCRIPTION
There is no need nowadays to rely on AUTO platform features.

Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>