### PR TITLE
[9.12] [4/5] Android.bp: Wrap in soong namespace and import display-commonsys-intf

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,3 +1,7 @@
+soong_namespace {
+    imports: ["vendor/qcom/opensource/display-commonsys-intf/sm8250"],
+}
+
 cc_defaults {
     name: "display_defaults",
     cflags: [


### PR DESCRIPTION
Wrap in a namespace so that BluePrint targets can coexist between the SM8150 (used for legacy devices) and SM8250 (Edo and upwards) HAL.
