### PR TITLE
[aosp/LA.UM.8.1.r1] display: Guard VINTF_FRAGMENTS for Q building

### DIFF
--- a/gralloc/Android.mk
+++ b/gralloc/Android.mk
@@ -78,7 +78,9 @@ LOCAL_SHARED_LIBRARIES        := $(common_libs) \
 LOCAL_CFLAGS                  := $(common_flags) -DLOG_TAG=\"qdgralloc\" -Wno-sign-conversion
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps)
 LOCAL_SRC_FILES               := QtiMapper.cpp QtiMapperExtensions.cpp
+ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 30),)
 LOCAL_VINTF_FRAGMENTS         := android.hardware.graphics.mapper-impl-qti-display.xml
+endif
 include $(BUILD_SHARED_LIBRARY)
 
 #allocator
@@ -102,5 +104,7 @@ LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps)
 LOCAL_C_INCLUDES              := $(kernel_includes)
 LOCAL_SRC_FILES               := QtiAllocator.cpp service.cpp
 LOCAL_INIT_RC                 := vendor.qti.hardware.display.allocator-service.rc
+ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 30),)
 LOCAL_VINTF_FRAGMENTS         := vendor.qti.hardware.display.allocator-service.xml
+endif
 include $(BUILD_EXECUTABLE)

--- a/sdm/libs/hwc2/Android.mk
+++ b/sdm/libs/hwc2/Android.mk
@@ -62,7 +62,9 @@ LOCAL_SRC_FILES               := hwc_session.cpp \
                                  hwc_socket_handler.cpp \
                                  hwc_buffer_allocator.cpp
 
+ifneq ($(call math_gt_or_eq, $(PLATFORM_SDK_VERSION), 30),)
 LOCAL_VINTF_FRAGMENTS         := vendor.qti.hardware.display.composer-service.xml
+endif
 
 include $(BUILD_SHARED_LIBRARY)
 endif


### PR DESCRIPTION
Related with https://github.com/sonyxperiadev/device-sony-common/pull/850