### PR TITLE
[9.12] Cherry-picks for building Android S

### DIFF
--- a/composer/hwc_session.cpp
+++ b/composer/hwc_session.cpp
@@ -828,8 +828,8 @@ void HWCSession::HandlePendingRefresh() {
   for (size_t i = 0; i < pending_refresh_.size(); i++) {
     if (pending_refresh_.test(i)) {
       callbacks_.Refresh(i);
+      break;
     }
-    break;
   }
 
   pending_refresh_.reset();

--- a/gpu_tonemapper/glengine.cpp
+++ b/gpu_tonemapper/glengine.cpp
@@ -314,8 +314,10 @@ int engine_blit(int srcFenceFd)
 void checkGlError(const char *file, int line)
 //-----------------------------------------------------------------------------
 {
-  for (GLint error = glGetError(); error; error = glGetError()) {
-    char *pError;
+  GLint error = glGetError();
+  while (error !=  GL_NO_ERROR) {
+    error = glGetError();
+    char *pError = nullptr;
     switch (error) {
       case GL_NO_ERROR:
         pError = (char *)"GL_NO_ERROR";
@@ -338,7 +340,7 @@ void checkGlError(const char *file, int line)
 
       default:
         ALOGE("glError (0x%x) %s:%d\n", error, file, line);
-        return;
+        break;
     }
 
     ALOGE("glError (%s) %s:%d\n", pError, file, line);
@@ -357,7 +359,7 @@ void checkEglError(const char *file, int line)
       break;
     }
 
-    char *pError;
+    char *pError = nullptr;
     switch (error) {
       case EGL_SUCCESS:
         pError = (char *)"EGL_SUCCESS";
@@ -409,7 +411,6 @@ void checkEglError(const char *file, int line)
         return;
     }
     ALOGE("eglError (%s) %s:%d\n", pError, file, line);
-    return;
   }
   return;
 }

--- a/sde-drm/drm_connector.cpp
+++ b/sde-drm/drm_connector.cpp
@@ -502,7 +502,7 @@ void DRMConnector::ParseCapabilities(uint64_t blob_id, DRMConnectorInfo *info) {
   fmt_str[blob->length] = '\0';
   stringstream stream(fmt_str);
   DRM_LOGI("stream str %s len %zu blob str %s len %d", stream.str().c_str(), stream.str().length(),
-           blob->data, blob->length);
+           static_cast<const char *>(blob->data), blob->length);
   string line = {};
   const string display_type = "display type=";
   const string panel_name = "panel name=";
@@ -590,7 +590,7 @@ void DRMConnector::ParseModeProperties(uint64_t blob_id, DRMConnectorInfo *info)
   fmt_str[blob->length] = '\0';
   stringstream stream(fmt_str);
   DRM_LOGI("stream str %s len %zu blob str %s len %d", stream.str().c_str(), stream.str().length(),
-           blob->data, blob->length);
+           static_cast<const char *>(blob->data), blob->length);
 
   string line = {};
   const string mode_name = "mode_name=";

--- a/sde-drm/drm_crtc.cpp
+++ b/sde-drm/drm_crtc.cpp
@@ -328,7 +328,7 @@ void DRMCrtc::ParseCapabilities(uint64_t blob_id) {
   fmt_str[blob->length] = '\0';
   stringstream stream(fmt_str);
   DRM_LOGI("stream str %s len %zu blob str %s len %d", stream.str().c_str(), stream.str().length(),
-           blob->data, blob->length);
+           static_cast<const char *>(blob->data), blob->length);
   string line = {};
   string max_blendstages = "max_blendstages=";
   string qseed_type = "qseed_type=";

--- a/sde-drm/drm_plane.cpp
+++ b/sde-drm/drm_plane.cpp
@@ -452,7 +452,7 @@ void DRMPlane::GetTypeInfo(const PropertyMap &prop_map) {
   // like formats etc
   stringstream stream(fmt_str);
   DRM_LOGI("stream str %s len %zu blob str %s len %d", stream.str().c_str(), stream.str().length(),
-           blob->data, blob->length);
+           static_cast<const char *>(blob->data), blob->length);
 
   string line = {};
   string pixel_formats = "pixel_formats=";


### PR DESCRIPTION
Break misplaced in merge conflict.

---

Cherry-picked from a random CAF patch ([2b04dd3fccf87a249199c5cb5fa51b7ab676742d](https://source.codeaurora.org/quic/la/platform/hardware/qcom/display/commit/?id=2b04dd3fccf87a249199c5cb5fa51b7ab676742d)), but AOSP independently "found" this mistake on S with better clang instrumentation:

https://cs.android.com/android/_/android/platform/hardware/qcom/sm7250/display/+/8fafce5251687d31d38615c4e9a7efb21a3b1880
https://android-review.googlesource.com/c/platform/hardware/qcom/sm8150/display/+/1348310
